### PR TITLE
Fix file truncation from Emscripten

### DIFF
--- a/src/generic/emscripten_fs.ts
+++ b/src/generic/emscripten_fs.ts
@@ -226,7 +226,12 @@ class BFSEmscriptenNodeOps implements EmscriptenNodeOps {
       }
     }
     if (attr.size !== undefined) {
-      fs.truncateSync(path, attr.size);
+      try {
+        fs.truncateSync(path, attr.size);
+      } catch (e) {
+        if (!e.code) throw e;
+        throw new this.FS.ErrnoError(this.ERRNO_CODES[e.code]);
+      }
     }
   }
 

--- a/src/generic/emscripten_fs.ts
+++ b/src/generic/emscripten_fs.ts
@@ -217,17 +217,16 @@ class BFSEmscriptenNodeOps implements EmscriptenNodeOps {
         var date = new Date(attr.timestamp);
         fs.utimesSync(path, date, date);
       }
-      if (attr.size !== undefined) {
-        fs.truncateSync(path, attr.size);
-      }
     } catch (e) {
       if (!e.code) throw e;
-      if (e.code === "ENOTSUP") {
-        // Ignore not supported errors. Emscripten does utimesSync when it
-        // writes files, but never really requires the value to be set.
-        return;
+      // Ignore not supported errors. Emscripten does utimesSync when it
+      // writes files, but never really requires the value to be set.
+      if (e.code !== "ENOTSUP") {
+        throw new this.FS.ErrnoError(this.ERRNO_CODES[e.code]);
       }
-      throw new this.FS.ErrnoError(this.ERRNO_CODES[e.code]);
+    }
+    if (attr.size !== undefined) {
+      fs.truncateSync(path, attr.size);
     }
   }
 


### PR DESCRIPTION
Previously, a failure of fs.utimesSync() would cause
fs.truncateSync() to be skipped. Since Emscripten sets both
time and size when truncating, this meant that truncation
did nothing.

I think size setting ENOTSUP must not be ignored, because it affects data integrity.

I'm not sure if chmod ENOTSUP should be ignored. I chose to ignore it because it was ignored before.