### PR TITLE
Generate browserfs-umd.js and browserfs-umd.min.js

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -224,6 +224,23 @@ module.exports = function(grunt) {
         }
       }
     },
+    umd: {
+      options: {
+        objectToExport: 'BrowserFS'
+      },
+      all: {
+        options: {
+          src: 'build/release/browserfs.js',
+          dest: 'build/release/browserfs-umd.js'
+        }
+      },
+      min: {
+        options: {
+          src: 'build/release/browserfs.min.js',
+          dest: 'build/release/browserfs-umd.min.js'
+        }
+      }
+    },
     shell: {
       gen_cert: {
         command: [
@@ -263,6 +280,7 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-watch');
   grunt.loadNpmTasks('grunt-contrib-connect');
   grunt.loadNpmTasks('grunt-contrib-requirejs');
+  grunt.loadNpmTasks('grunt-umd');
   grunt.loadNpmTasks('grunt-karma');
   grunt.loadNpmTasks('grunt-shell');
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -230,14 +230,14 @@ module.exports = function(grunt) {
       },
       all: {
         options: {
-          src: 'build/release/browserfs-umd.js',
-          dest: 'build/release/browserfs-umd.js'
+          src: 'build/release/browserfs.js',
+          dest: 'build/release/browserfs.js'
         }
       },
       min: {
         options: {
           src: 'build/release/browserfs.min.js',
-          dest: 'build/release/browserfs-umd.min.js'
+          dest: 'build/release/browserfs.min.js'
         }
       }
     },
@@ -297,7 +297,7 @@ module.exports = function(grunt) {
     var derequire = require('derequire');
 
     var code = derequire(fs.readFileSync('./build/release/browserfs.js'));
-    fs.writeFileSync('./build/release/browserfs-umd.js', code);
+    fs.writeFileSync('./build/release/browserfs.js', code);
   });
 
   // test

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -302,7 +302,7 @@ module.exports = function(grunt) {
   // dev build + watch for changes.
   grunt.registerTask('watch', ['ts:watch']);
   // release build (default)
-  grunt.registerTask('default', ['ts:dev', 'requirejs']);
+  grunt.registerTask('default', ['ts:dev', 'requirejs', 'umd']);
   // testling
   grunt.registerTask('testling', ['default', 'shell:gen_listings', 'shell:gen_zipfs_fixtures', 'shell:load_fixtures']);
 };

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -230,7 +230,7 @@ module.exports = function(grunt) {
       },
       all: {
         options: {
-          src: 'build/release/browserfs.js',
+          src: 'build/release/browserfs-umd.js',
           dest: 'build/release/browserfs-umd.js'
         }
       },
@@ -293,6 +293,13 @@ module.exports = function(grunt) {
     removeDir('./test/fixtures/zipfs');
   });
 
+  grunt.registerTask('derequire', 'Apply derequire to output for umd script', function() {
+    var derequire = require('derequire');
+
+    var code = derequire(fs.readFileSync('./build/release/browserfs.js'));
+    fs.writeFileSync('./build/release/browserfs-umd.js', code);
+  });
+
   // test
   grunt.registerTask('test', ['ts:test', 'shell:gen_zipfs_fixtures', 'shell:gen_listings', 'shell:load_fixtures', 'connect', 'karma:test']);
   // testing dropbox
@@ -302,7 +309,7 @@ module.exports = function(grunt) {
   // dev build + watch for changes.
   grunt.registerTask('watch', ['ts:watch']);
   // release build (default)
-  grunt.registerTask('default', ['ts:dev', 'requirejs', 'umd']);
+  grunt.registerTask('default', ['ts:dev', 'requirejs', 'derequire', 'umd']);
   // testling
   grunt.registerTask('testling', ['default', 'shell:gen_listings', 'shell:gen_zipfs_fixtures', 'shell:load_fixtures']);
 };

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "serve-static": "^1.8.1",
     "typescript": "~1.4",
     "xhr2": "*",
-    "zlibjs": "*"
+    "zlibjs": "*",
+    "grunt-umd": "~2.3.3"
   },
   "scripts": {
     "//": "Testling doesn't have Bower installed globally.",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "typescript": "~1.4",
     "xhr2": "*",
     "zlibjs": "*",
-    "grunt-umd": "~2.3.3"
+    "grunt-umd": "~2.3.3",
+    "derequire": "~2.0.0"
   },
   "scripts": {
     "//": "Testling doesn't have Bower installed globally.",


### PR DESCRIPTION
This is a naive fix to #107. It creates two grunt task to generaate the two required files while keeping the original intro/outro setup. Due to the way requirejs works the umd part of `browserfs-umd.min.js` is actually not minified.