### PR TITLE
Optimizations, OverlayFS, and AsyncMirrorFS

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -149,7 +149,7 @@ module.exports = function(grunt) {
         colors: true,
         logLevel: 'INFO',
         autoWatch: true,
-        browsers: ['Firefox'],
+        browsers: ['Chrome'],
         captureTimeout: 60000,
         // Avoid hardcoding and cross-origin issues.
         proxies: {

--- a/src/backend/XmlHttpRequest.ts
+++ b/src/backend/XmlHttpRequest.ts
@@ -294,7 +294,7 @@ export class XmlHttpRequest extends file_system.BaseFileSystem implements file_s
         });
       };
       var fdCast = <preload_file.NoSyncFile> fd;
-      var fdBuff = <buffer.Buffer> fdCast._buffer;
+      var fdBuff = <buffer.Buffer> fdCast.getBuffer();
       if (encoding === null) {
         if (fdBuff.length > 0) {
           return cb(err, fdBuff.sliceCopy());
@@ -318,7 +318,7 @@ export class XmlHttpRequest extends file_system.BaseFileSystem implements file_s
     var fd = this.openSync(fname, flag, 0x1a4);
     try {
       var fdCast = <preload_file.NoSyncFile> fd;
-      var fdBuff = <buffer.Buffer> fdCast._buffer;
+      var fdBuff = <buffer.Buffer> fdCast.getBuffer();
       if (encoding === null) {
         if (fdBuff.length > 0) {
           return fdBuff.sliceCopy();

--- a/src/backend/async_mirror.ts
+++ b/src/backend/async_mirror.ts
@@ -75,7 +75,7 @@ class AsyncMirrorFS extends file_system.SynchronousFileSystem implements file_sy
   }
   
   public _syncSync(fd: preload_file.PreloadFile) {
-    this._sync.writeFileSync(fd.getPath(), fd.getBuffer(), null, fd.getFlag(), fd.getStats().mode);
+    this._sync.writeFileSync(fd.getPath(), fd.getBuffer(), null, file_flag.FileFlag.getFileFlag('w'), fd.getStats().mode);
     this.enqueueOp({
       apiMethod: 'writeFile',
       arguments: [fd.getPath(), fd.getBuffer(), null, fd.getFlag(), fd.getStats().mode]

--- a/src/backend/async_mirror.ts
+++ b/src/backend/async_mirror.ts
@@ -155,6 +155,7 @@ class AsyncMirrorFS extends file_system.SynchronousFileSystem implements file_sy
   private enqueueOp(op: IAsyncOperation) {
     this._queue.push(op);
     if (!this._queueRunning) {
+      this._queueRunning = true;
       var doNextOp = (err?: ApiError) => {
         if (err) {
           console.error(`WARNING: File system has desynchronized. Received following error: ${err}\n$`);

--- a/src/backend/async_mirror.ts
+++ b/src/backend/async_mirror.ts
@@ -1,0 +1,243 @@
+import file_system = require('../core/file_system');
+import buffer = require('../core/buffer');
+import api_error = require('../core/api_error');
+import file_flag = require('../core/file_flag');
+import util = require('../core/util');
+import file = require('../core/file');
+import node_fs_stats = require('../core/node_fs_stats');
+import preload_file = require('../generic/preload_file');
+import browserfs = require('../core/browserfs');
+import ApiError = api_error.ApiError;
+import ErrorCode = api_error.ErrorCode;
+
+interface IAsyncOperation {
+	apiMethod: string;
+	arguments: any[];
+}
+
+/**
+ * We define our own file to interpose on syncSync() for mirroring purposes.
+ */
+class MirrorFile extends preload_file.PreloadFile implements file.File {
+  constructor(fs: AsyncMirrorFS, path: string, flag: file_flag.FileFlag, stat: node_fs_stats.Stats, data: Buffer) {
+    super(fs, path, flag, stat, data);
+  }
+
+  public syncSync(): void {
+    if (this.isDirty()) {
+      (<AsyncMirrorFS> this._fs)._syncSync(this);
+      this.resetDirty();
+    }
+  }
+  
+  public closeSync(): void {
+    this.syncSync();
+  }
+}
+
+/**
+ * AsyncMirrorFS mirrors a synchronous filesystem into an asynchronous filesystem
+ * by:
+ * * Performing operations over the in-memory copy, while asynchronously pipelining them
+ *   to the backing store.
+ * * During application loading, the contents of the async file system can be reloaded into
+ *   the synchronous store, if desired.
+ * The two stores will be kept in sync. The most common use-case is to pair a synchronous
+ * in-memory filesystem with an asynchronous backing store.
+ */
+class AsyncMirrorFS extends file_system.SynchronousFileSystem implements file_system.FileSystem {
+  /**
+   * Queue of pending asynchronous operations.
+   */
+  private _queue: IAsyncOperation[] = [];
+  private _queueRunning: boolean = false;
+  private _sync: file_system.FileSystem;
+  private _async: file_system.FileSystem;
+  private _isInitialized: boolean = false;
+  constructor(sync: file_system.FileSystem, async: file_system.FileSystem) {
+    super();
+    this._sync = sync;
+    this._async = async;
+    if (!sync.supportsSynch()) {
+      throw new Error("Expected synchronous storage.");
+    }
+    if (async.supportsSynch()) {
+      throw new Error("Expected asynchronous storage.");
+    }
+  }
+
+  public getName(): string {
+	 	return "AsyncMirror";
+  }
+  
+  public static isAvailable(): boolean {
+    return true;
+  }
+  
+  public _syncSync(fd: preload_file.PreloadFile) {
+    this._sync.writeFileSync(fd.getPath(), fd.getBuffer(), null, fd.getFlag(), fd.getStats().mode);
+    this.enqueueOp({
+      apiMethod: 'writeFile',
+      arguments: [fd.getPath(), fd.getBuffer(), null, fd.getFlag(), fd.getStats().mode]
+    });
+  }
+  
+  /**
+   * Called once to load up files from async storage into sync storage.
+   */
+  public initialize(finalCb: (err?: ApiError) => void): void {
+    if (!this._isInitialized) {
+      var copyDirectory = (p: string, mode: number, cb: (err?: ApiError) => void) => {
+        if (p !== '/') {
+          this._sync.mkdirSync(p, mode);
+        }
+        this._async.readdir(p, (err, files) => {
+          if (err) {
+            cb(err);
+          } else {
+            var i = 0;
+            function copyNextFile(err?: ApiError) {
+              if (err) {
+                cb(err);
+              } else if (i < files.length) {
+                copyItem(`${p}/${files[i]}`, copyNextFile);
+                i++;
+              } else {
+                cb();
+              }
+            }
+            copyNextFile();
+          }
+        });
+      }, copyFile = (p: string, mode: number, cb: (err?: ApiError) => void) => {
+        this._async.readFile(p, null, file_flag.FileFlag.getFileFlag('r'), (err, data) => {
+          if (err) {
+            cb(err);
+          } else {
+            try {
+              this._sync.writeFileSync(p, data, null, file_flag.FileFlag.getFileFlag('w'), mode);
+            } catch (e) {
+              err = e;
+            } finally {
+              cb(err);
+            }
+          }
+        });
+      }, copyItem = (p: string, cb: (err?: ApiError) => void) => {
+        this._async.stat(p, false, (err, stats) => {
+          if (err) {
+            cb(err);
+          } else if (stats.isDirectory()) {
+            copyDirectory(p, stats.mode, cb);
+          } else {
+            copyFile(p, stats.mode, cb);
+          }
+        });
+      };
+      copyDirectory('/', 0, (err?: ApiError) => {
+        if (err) {
+          finalCb(err);
+        } else {
+          this._isInitialized = true;
+          finalCb();
+        }
+      });
+    } else {
+      finalCb();
+    }
+  }
+
+  public isReadOnly(): boolean { return false; }
+  public supportsSynch(): boolean { return true; }
+  public supportsLinks(): boolean { return false; }
+  public supportsProps(): boolean { return this._sync.supportsProps() && this._async.supportsProps(); }
+  
+  private enqueueOp(op: IAsyncOperation) {
+    this._queue.push(op);
+    if (!this._queueRunning) {
+      var doNextOp = (err?: ApiError) => {
+        if (err) {
+          console.error(`WARNING: File system has desynchronized. Received following error: ${err}\n$`);
+        }
+        if (this._queue.length > 0) {
+          var op = this._queue.shift(),
+            args = op.arguments;
+          args.push(doNextOp);
+          (<Function> this._async[op.apiMethod]).apply(this._async, args);
+        } else {
+          this._queueRunning = false;
+        }
+      };
+      doNextOp();
+    }
+  }
+
+  public renameSync(oldPath: string, newPath: string): void {
+    this._sync.renameSync(oldPath, newPath);
+    this.enqueueOp({
+      apiMethod: 'rename',
+      arguments: [oldPath, newPath]
+    });
+  }
+  public statSync(p: string, isLstat: boolean): node_fs_stats.Stats {
+    return this._sync.statSync(p, isLstat);
+  }
+  public openSync(p: string, flag: file_flag.FileFlag, mode: number): file.File {
+    // Sanity check: Is this open/close permitted?
+    var fd = this._sync.openSync(p, flag, mode);
+    fd.closeSync();
+    return new MirrorFile(this, p, flag, this._sync.statSync(p, false), this._sync.readFileSync(p, null, file_flag.FileFlag.getFileFlag('r')));
+  }
+  public unlinkSync(p: string): void {
+    this._sync.unlinkSync(p);
+    this.enqueueOp({
+      apiMethod: 'unlink',
+      arguments: [p]
+    });
+  }
+  public rmdirSync(p: string): void {
+    this._sync.rmdirSync(p);
+    this.enqueueOp({
+      apiMethod: 'rmdir',
+      arguments: [p]
+    });
+  }
+  public mkdirSync(p: string, mode: number): void {
+    this._sync.mkdirSync(p, mode);
+    this.enqueueOp({
+      apiMethod: 'mkdir',
+      arguments: [p, mode]
+    });
+  }
+  public readdirSync(p: string): string[] {
+    return this._sync.readdirSync(p);
+  }
+  public existsSync(p: string): boolean {
+    return this._sync.existsSync(p);
+  }
+  public chmodSync(p: string, isLchmod: boolean, mode: number): void {
+    this._sync.chmodSync(p, isLchmod, mode);
+    this.enqueueOp({
+      apiMethod: 'chmod',
+      arguments: [p, isLchmod, mode]
+    });
+  }
+  public chownSync(p: string, isLchown: boolean, uid: number, gid: number): void {
+    this._sync.chownSync(p, isLchown, uid, gid);
+    this.enqueueOp({
+      apiMethod: 'chown',
+      arguments: [p, isLchown, uid, gid]
+    });
+  }
+  public utimesSync(p: string, atime: Date, mtime: Date): void {
+    this._sync.utimesSync(p, atime, mtime);
+    this.enqueueOp({
+      apiMethod: 'utimes',
+      arguments: [p, atime, mtime]
+    });
+  }
+}
+
+browserfs.registerFileSystem('AsyncMirrorFS', AsyncMirrorFS);
+
+export = AsyncMirrorFS;

--- a/src/backend/overlay.ts
+++ b/src/backend/overlay.ts
@@ -7,6 +7,8 @@ import file = require('../core/file');
 import node_fs_stats = require('../core/node_fs_stats');
 import preload_file = require('../generic/preload_file');
 import browserfs = require('../core/browserfs');
+import node_path = require('../core/node_path');
+import path = node_path.path;
 
 var deletionLogPath = '/.deletedFiles.log';
 
@@ -21,8 +23,8 @@ function makeModeWritable(mode: number): number {
  * Overlays a RO file to make it writable.
  */
 class OverlayFile extends preload_file.PreloadFile implements file.File {
-  constructor(fs: OverlayFS, path: string, flag: file_flag.FileFlag) {
-    super(fs, path, flag, fs.statSync(path, false), fs.readFileSync(path, null, flag));
+  constructor(fs: OverlayFS, path: string, flag: file_flag.FileFlag, stats: node_fs_stats.Stats, data: Buffer) {
+    super(fs, path, flag, stats, data);
   }
 
   public syncSync(): void {
@@ -48,11 +50,12 @@ class OverlayFS extends file_system.SynchronousFileSystem implements file_system
   private _writable: file_system.FileSystem;
   private _readable: file_system.FileSystem;
   private _isInitialized: boolean = false;
-  private _deletedFiles: {[path: string]: boolean};
+  private _deletedFiles: {[path: string]: boolean} = {};
   private _deleteLog: file.File = null;
   
   constructor(writable: file_system.FileSystem, readable: file_system.FileSystem) {
     super();
+    console.log("Constructor.");
     this._writable = writable;
     this._readable = readable;
     if (this._writable.isReadOnly()) {
@@ -63,7 +66,29 @@ class OverlayFS extends file_system.SynchronousFileSystem implements file_system
     }
   }
   
+  /**
+   * With the given path, create the needed parent directories on the writable storage
+   * should they not exist. Use modes from the read-only storage.
+   */
+  private createParentDirectories(p: string): void {
+    var parent = path.dirname(p), toCreate: string[] = [];
+    while (!this._writable.existsSync(parent)) {
+      toCreate.push(parent);
+      parent = path.dirname(parent);
+    }
+    
+    toCreate.forEach((p: string) => {
+      this._writable.mkdirSync(p, this.statSync(p, false).mode);
+    });
+  }
+  
+  public static isAvailable(): boolean {
+    return true;
+  }
+  
   public _syncSync(file: preload_file.PreloadFile): void {
+    console.log("_syncSync");
+    this.createParentDirectories(file.getPath());
     this._writable.writeFileSync(file.getPath(), file.getBuffer(), null, file.getFlag(), file.getStats().mode);
   }
   
@@ -75,12 +100,16 @@ class OverlayFS extends file_system.SynchronousFileSystem implements file_system
    * Called once to load up metadata stored on the writable file system. 
    */
   public initialize(cb: (err?: api_error.ApiError) => void): void {
+    console.log("Initialize.");
     if (!this._isInitialized) {
       // Read deletion log, process into metadata.
       this._writable.readFile(deletionLogPath, 'utf8',
         file_flag.FileFlag.getFileFlag('r'), (err: api_error.ApiError, data?: string) => {
         if (err) {
-          cb(err);
+          // ENOENT === Newly-instantiated file system, and thus empty log.
+          if (err.type !== api_error.ErrorCode.ENOENT) {
+            return cb(err);
+          }
         } else {
           data.split('\n').forEach((path: string) => {
             // If the log entry begins w/ 'd', it's a deletion. Otherwise, it's
@@ -88,17 +117,17 @@ class OverlayFS extends file_system.SynchronousFileSystem implements file_system
             // TODO: Clean up log during initialization phase.
             this._deletedFiles[path.slice(1)] = path.slice(0, 1) === 'd';
           });
-          // Open up the deletion log for appending.
-          this._writable.open(deletionLogPath, file_flag.FileFlag.getFileFlag('a'),
-            0x1a4, (err: api_error.ApiError, fd?: file.File) => {
-            if (err) {
-              cb(err);
-            } else {
-              this._deleteLog = fd;
-              cb();
-            }
-          });
         }
+        // Open up the deletion log for appending.
+        this._writable.open(deletionLogPath, file_flag.FileFlag.getFileFlag('a'),
+          0x1a4, (err: api_error.ApiError, fd?: file.File) => {
+          if (err) {
+            cb(err);
+          } else {
+            this._deleteLog = fd;
+            cb();
+          }
+        });
       });
     } else {
       cb();
@@ -111,6 +140,7 @@ class OverlayFS extends file_system.SynchronousFileSystem implements file_system
   public supportsProps(): boolean { return this._readable.supportsProps() && this._writable.supportsProps(); }
 
   private deletePath(p: string): void {
+    console.log(`deletePath ${p}`);
     this._deletedFiles[p] = true;
     var buff = new Buffer("d" + p);
     this._deleteLog.writeSync(buff, 0, buff.length, null);
@@ -118,6 +148,7 @@ class OverlayFS extends file_system.SynchronousFileSystem implements file_system
   }
   
   private undeletePath(p: string): void {
+    console.log(`undeletePath ${p}`);
     if (this._deletedFiles[p]) {
       this._deletedFiles[p] = false;
       var buff = new Buffer("u" + p);
@@ -127,6 +158,7 @@ class OverlayFS extends file_system.SynchronousFileSystem implements file_system
   }
 
   public renameSync(oldPath: string, newPath: string): void {
+    console.log(`renameSync ${oldPath} => ${newPath}`);
     if (this.existsSync(newPath)) {
       throw new api_error.ApiError(api_error.ErrorCode.EEXIST, `Path ${newPath} already exists.`);
     }
@@ -138,6 +170,7 @@ class OverlayFS extends file_system.SynchronousFileSystem implements file_system
     this.unlinkSync(oldPath);
   }
   public statSync(p: string, isLstat: boolean): node_fs_stats.Stats {
+    console.log(`statSync ${p}`);
     try {
       return this._writable.statSync(p, isLstat);
     } catch (e) {
@@ -152,16 +185,33 @@ class OverlayFS extends file_system.SynchronousFileSystem implements file_system
     }
   }
   public openSync(p: string, flag: file_flag.FileFlag, mode: number): file.File {
-    if (this._writable.existsSync(p)) {
-      return this._writable.openSync(p, flag, mode);
-    } else if (this.existsSync(p)) {
-      // Open in an OverlayFile so the program can write to it if desired.
-      return new OverlayFile(this, p, flag);
+    console.log(`openSync ${p}`);
+    if (this.existsSync(p)) {
+      switch (flag.pathExistsAction()) {
+        case file_flag.ActionType.TRUNCATE_FILE:
+          this.createParentDirectories(p);
+          return this._writable.openSync(p, flag, mode);
+        case file_flag.ActionType.NOP:
+          // Copy from readable first.
+          if (this._readable.existsSync(p)) {
+            this.copyToWritable(p);
+          }
+          return this._writable.openSync(p, flag, mode);
+        default:
+          throw new api_error.ApiError(api_error.ErrorCode.ENOENT, `Path ${p} does not exist.`);
+      }
     } else {
-      throw new api_error.ApiError(api_error.ErrorCode.ENOENT, `Path ${p} does not exist.`);
+      switch(flag.pathNotExistsAction()) {
+        case file_flag.ActionType.CREATE_FILE:
+          this.createParentDirectories(p);
+          return this._writable.openSync(p, flag, mode);
+        default:
+          throw new api_error.ApiError(api_error.ErrorCode.EEXIST, `Path ${p} exists.`);
+      }
     }
   }
   public unlinkSync(p: string): void {
+    console.log(`unlinkSync ${p}`);
     if (this._writable.existsSync(p)) {
       this._writable.unlinkSync(p);
     }
@@ -172,6 +222,7 @@ class OverlayFS extends file_system.SynchronousFileSystem implements file_system
     }
   }
   public rmdirSync(p: string): void {
+    console.log(`rmdirSync ${p}`);
     if (this._writable.existsSync(p)) {
       this._writable.rmdirSync(p);
     }
@@ -185,13 +236,18 @@ class OverlayFS extends file_system.SynchronousFileSystem implements file_system
     }
   }
   public mkdirSync(p: string, mode: number): void {
+    console.log(`mkdirSync ${p}`);
     if (this.existsSync(p)) {
       throw new api_error.ApiError(api_error.ErrorCode.EEXIST, `Path ${p} already exists.`);
     } else {
+      // The below will throw should any of the parent directories fail to exist
+      // on _writable.
+      this.createParentDirectories(p);
       this._writable.mkdirSync(p, mode);
     }
   }
   public readdirSync(p: string): string[] {
+    console.log(`readdirSync ${p}`);
     var dirStats = this.statSync(p, false);
     if (!dirStats.isDirectory()) {
       throw new api_error.ApiError(api_error.ErrorCode.ENOTDIR, `Path ${p} is not a directory.`);
@@ -210,19 +266,23 @@ class OverlayFS extends file_system.SynchronousFileSystem implements file_system
     return contents.filter((fileP: string) => this._deletedFiles[p + "/" + fileP] !== true);
   }
   public existsSync(p: string): boolean {
+    console.log(`existsSync ${p}`);
     return this._writable.existsSync(p) || (this._readable.existsSync(p) && this._deletedFiles[p] !== true);
   }
   public chmodSync(p: string, isLchmod: boolean, mode: number): void {
+    console.log(`chmodSync ${p}`);
     this.operateOnWritable(p, () => {
       this._writable.chmodSync(p, isLchmod, mode);
     });
   }
   public chownSync(p: string, isLchown: boolean, uid: number, gid: number): void {
+    console.log(`chownSync ${p}`);
     this.operateOnWritable(p, () => {
       this._writable.chownSync(p, isLchown, uid, gid);
     });
   }
   public utimesSync(p: string, atime: Date, mtime: Date): void {
+    console.log(`utimesSync ${p}`);
     this.operateOnWritable(p, () => {
       this._writable.utimesSync(p, atime, mtime);
     });
@@ -263,5 +323,7 @@ class OverlayFS extends file_system.SynchronousFileSystem implements file_system
     }
   }
 }
+
+browserfs.registerFileSystem('IndexedDB', OverlayFS);
 
 export = OverlayFS;

--- a/src/backend/overlay.ts
+++ b/src/backend/overlay.ts
@@ -1,0 +1,224 @@
+import file_system = require('../core/file_system');
+import buffer = require('../core/buffer');
+import api_error = require('../core/api_error');
+import file_flag = require('../core/file_flag');
+import util = require('../core/util');
+import file = require('../core/file');
+import node_fs_stats = require('../core/node_fs_stats');
+import preload_file = require('../generic/preload_file');
+import browserfs = require('../core/browserfs');
+
+var deletionLogPath = '/.deletedFiles.log';
+
+/**
+ * Given a read-only mode, makes it writable.
+ */
+function makeModeWritable(mode: number): number {
+  return 0x92 | mode;
+}
+
+/**
+ * Overlays a RO file to make it writable.
+ */
+class OverlayFile extends preload_file.PreloadFile implements file.File {
+  constructor(fs: OverlayFS, path: string, flag: file_flag.FileFlag) {
+    super(fs, path, flag, fs.statSync(path, false), fs.readFileSync(path, null, flag));
+  }
+
+  public syncSync(): void {
+    if (this.isDirty()) {
+      (<OverlayFS> this._fs)._syncSync(this);
+      this.resetDirty();
+    }
+  }
+  
+  public closeSync(): void {
+    this.syncSync();
+  }
+}
+
+/**
+ * OverlayFS makes a read-only filesystem writable by storing writes on a second,
+ * writable file system. Deletes are persisted via metadata stored on the writable
+ * file system.
+ * 
+ * Currently only works for two synchronous file systems.
+ */
+class OverlayFS extends file_system.SynchronousFileSystem implements file_system.FileSystem {
+  private _writable: file_system.FileSystem;
+  private _readable: file_system.FileSystem;
+  private _isInitialized: boolean = false;
+  private _deletedFiles: {[path: string]: boolean};
+  private _deleteLog: file.File = null;
+  
+  constructor(writable: file_system.FileSystem, readable: file_system.FileSystem) {
+    super();
+    this._writable = writable;
+    this._readable = readable;
+    if (this._writable.isReadOnly()) {
+      throw new api_error.ApiError(api_error.ErrorCode.EINVAL, "Writable file system must be writable.");
+    }    
+    if (!this._writable.supportsSynch() || !this._readable.supportsSynch()) {
+      throw new api_error.ApiError(api_error.ErrorCode.EINVAL, "OverlayFS currently only operates on synchronous file systems.");
+    }
+  }
+  
+  public _syncSync(file: preload_file.PreloadFile): void {
+    this._writable.writeFileSync(file.getPath(), file.getBuffer(), null, file.getFlag(), file.getStats().mode);
+  }
+  
+  public getName() {
+    return "OverlayFS";
+  }
+  
+  /**
+   * Called once to load up metadata stored on the writable file system. 
+   */
+  public initialize(cb: (err?: api_error.ApiError) => void): void {
+    if (!this._isInitialized) {
+      // Read deletion log, process into metadata.
+      this._writable.readFile(deletionLogPath, 'utf8',
+        file_flag.FileFlag.getFileFlag('r'), (err: api_error.ApiError, data?: string) => {
+        if (err) {
+          cb(err);
+        } else {
+          data.split('\n').forEach((path: string) => {
+            // If the log entry begins w/ 'd', it's a deletion. Otherwise, it's
+            // an undeletion.
+            // TODO: Clean up log during initialization phase.
+            this._deletedFiles[path.slice(1)] = path.slice(0, 1) === 'd';
+          });
+          // Open up the deletion log for appending.
+          this._writable.open(deletionLogPath, file_flag.FileFlag.getFileFlag('a'),
+            0x1a4, (err: api_error.ApiError, fd?: file.File) => {
+            if (err) {
+              cb(err);
+            } else {
+              this._deleteLog = fd;
+              cb();
+            }
+          });
+        }
+      });
+    } else {
+      cb();
+    }
+  }
+
+  public isReadOnly(): boolean { return false; }
+  public supportsSynch(): boolean { return true; }
+  public supportsLinks(): boolean { return false; }
+  public supportsProps(): boolean { return this._readable.supportsProps() && this._writable.supportsProps(); }
+
+  private deletePath(p: string): void {
+    this._deletedFiles[p] = true;
+    var buff = new Buffer("d" + p);
+    this._deleteLog.writeSync(buff, 0, buff.length, null);
+  }
+  
+  private undeletePath(p: string): void {
+    if (this._deletedFiles[p]) {
+      this._deletedFiles[p] = false;
+      var buff = new Buffer("u" + p);
+      this._deleteLog.writeSync(buff, 0, buff.length, null);
+    }
+  }
+
+  public renameSync(oldPath: string, newPath: string): void {
+    if (this.existsSync(newPath)) {
+      throw new api_error.ApiError(api_error.ErrorCode.EEXIST, `Path ${newPath} already exists.`);
+    }
+    // Write newPath using oldPath's contents, delete oldPath.
+    var oldStats = this.statSync(oldPath, false);    
+    this.writeFileSync(newPath,
+      this.readFileSync(oldPath, null, file_flag.FileFlag.getFileFlag('r')), null,
+      file_flag.FileFlag.getFileFlag('w'), oldStats.mode);
+    this.unlinkSync(oldPath);
+  }
+  public statSync(p: string, isLstat: boolean): node_fs_stats.Stats {
+    try {
+      return this._writable.statSync(p, isLstat);
+    } catch (e) {
+      if (this._deletedFiles[p]) {
+        throw new api_error.ApiError(api_error.ErrorCode.ENOENT, `Path ${p} does not exist.`);
+      }
+      var oldStat = this._readable.statSync(p, isLstat).clone();
+      // Make the oldStat's mode writable. Preserve the topmost part of the
+      // mode, which specifies if it is a file or a directory.
+      oldStat.mode = makeModeWritable(oldStat.mode);
+      return oldStat;
+    }
+  }
+  public openSync(p: string, flag: file_flag.FileFlag, mode: number): file.File {
+    if (this._writable.existsSync(p)) {
+      return this._writable.openSync(p, flag, mode);
+    } else if (this.existsSync(p)) {
+      // note: we do not do this._readable.existsSync since it might be deleted. 
+      // open w/ readable flag, wrap in our thing.
+      // dirty bit.
+      // TODO: open the file, but make it writable.
+    }
+  }
+  public unlinkSync(p: string): void {
+    if (this._writable.existsSync(p)) {
+      this._writable.unlinkSync(p);
+    }
+    
+    if (this.existsSync(p)) {
+      // Add to delete log.
+      this.deletePath(p);
+    }
+  }
+  public rmdirSync(p: string): void {
+    if (this._writable.existsSync(p)) {
+      this._writable.rmdirSync(p);
+    }
+    if (this.existsSync(p)) {
+      // Check if directory is empty.
+      if (this.readdirSync(p).length > 0) {
+        throw new api_error.ApiError(api_error.ErrorCode.ENOTEMPTY, `Directory ${p} is not empty.`);
+      } else {
+        this.deletePath(p);
+      }
+    }
+  }
+  public mkdirSync(p: string, mode: number): void {
+    if (this.existsSync(p)) {
+      throw new api_error.ApiError(api_error.ErrorCode.EEXIST, `Path ${p} already exists.`);
+    } else {
+      this._writable.mkdirSync(p, mode);
+    }
+  }
+  public readdirSync(p: string): string[] {
+    var dirStats = this.statSync(p, false);
+    if (!dirStats.isDirectory()) {
+      throw new api_error.ApiError(api_error.ErrorCode.ENOTDIR, `Path ${p} is not a directory.`);
+    }
+    
+    // Readdir in both, merge, check delete log on each file, return.
+    var contents: string[] = [];
+    try {
+      contents = contents.concat(this._writable.readdirSync(p));
+    } catch (e) {
+    }
+    try {
+      contents = contents.concat(this._readable.readdirSync(p));
+    } catch (e) {
+    }
+    return contents.filter((fileP: string) => this._deletedFiles[p + "/" + fileP] !== true);
+  }
+  public existsSync(p: string): boolean {
+    return this._writable.existsSync(p) || (this._readable.existsSync(p) && this._deletedFiles[p] !== true);
+  }
+  public chmodSync(p: string, isLchmod: boolean, mode: number): void {
+    //
+  }
+  public chownSync(p: string, isLchown: boolean, uid: number, gid: number): void {
+    //
+  }
+  public utimesSync(p: string, atime: Date, mtime: Date): void {
+    //
+  }
+}
+
+export = OverlayFS;

--- a/src/backend/overlay.ts
+++ b/src/backend/overlay.ts
@@ -97,7 +97,7 @@ class OverlayFS extends file_system.SynchronousFileSystem implements file_system
   
   public _syncSync(file: preload_file.PreloadFile): void {
     this.createParentDirectories(file.getPath());
-    this._writable.writeFileSync(file.getPath(), file.getBuffer(), null, file.getFlag(), file.getStats().mode);
+    this._writable.writeFileSync(file.getPath(), file.getBuffer(), null, file_flag.FileFlag.getFileFlag('w'), file.getStats().mode);
   }
   
   public getName() {

--- a/src/backend/overlay.ts
+++ b/src/backend/overlay.ts
@@ -363,11 +363,9 @@ class OverlayFS extends file_system.SynchronousFileSystem implements file_system
     var pStats = this.statSync(p, false);
     if (pStats.isDirectory()) {
       this._writable.mkdirSync(p, pStats.mode);
-    } else {  
-      // No need to query the FS's directly. Use our write/read methods. Since the file
-      // isn't on the writable storage, the read will hit the readable storage.
+    } else {
       this.writeFileSync(p,
-        this.readFileSync(p, null, file_flag.FileFlag.getFileFlag('r')), null,
+        this._readable.readFileSync(p, null, file_flag.FileFlag.getFileFlag('r')), null,
         file_flag.FileFlag.getFileFlag('w'), this.statSync(p, false).mode);
     }
   }

--- a/src/backend/workerfs.ts
+++ b/src/backend/workerfs.ts
@@ -290,19 +290,32 @@ class WorkerFile extends preload_file.PreloadFile {
     return {
       type: SpecialArgType.FD,
       id: this._remoteFdId,
-      data: (<buffer.Buffer> this._buffer).toArrayBuffer(),
-      stat: (<buffer.Buffer> this._stat.toBuffer()).toArrayBuffer(),
-      path: this._path,
-      flag: this._flag.getFlagString()
+      data: (<buffer.Buffer> this.getBuffer()).toArrayBuffer(),
+      stat: (<buffer.Buffer> this.getStats().toBuffer()).toArrayBuffer(),
+      path: this.getPath(),
+      flag: this.getFlag().getFlagString()
     };
+  }
+  
+  private _syncClose(type: string, cb: (e?: api_error.ApiError) => void): void {
+    if (this.isDirty()) {
+      (<WorkerFS> this._fs).syncClose(type, this, (e?: api_error.ApiError) => {
+        if (!e) {
+          this.resetDirty();
+        }
+        cb(e);
+      });
+    } else {
+      cb();
+    }
   }
 
   public sync(cb: (e?: api_error.ApiError) => void): void {
-    (<WorkerFS> this._fs).syncClose('sync', this, cb);
+    this._syncClose('sync', cb);
   }
 
   public close(cb: (e?: api_error.ApiError) => void): void {
-    (<WorkerFS> this._fs).syncClose('close', this, cb);
+    this._syncClose('close', cb);
   }
 }
 

--- a/src/backend/zipfs.ts
+++ b/src/backend/zipfs.ts
@@ -577,7 +577,7 @@ export class ZipFS extends file_system.SynchronousFileSystem implements file_sys
     var fd = this.openSync(fname, flag, 0x1a4);
     try {
       var fdCast = <preload_file.NoSyncFile> fd;
-      var fdBuff = <buffer.Buffer> fdCast._buffer;
+      var fdBuff = <buffer.Buffer> fdCast.getBuffer();
       if (encoding === null) {
         if (fdBuff.length > 0) {
           return fdBuff.sliceCopy();

--- a/src/core/buffer.ts
+++ b/src/core/buffer.ts
@@ -302,9 +302,15 @@ export class Buffer implements BFSBuffer {
     if (sourceEnd > this.length) {
       throw new RangeError('sourceEnd out of bounds');
     }
-    var bytesCopied = Math.min(sourceEnd - sourceStart, target.length - targetStart, this.length - sourceStart);
-    // TODO: Optimize.
-    for (var i = 0; i < bytesCopied; i++) {
+    var bytesCopied = Math.min(sourceEnd - sourceStart, target.length - targetStart, this.length - sourceStart),
+      i: number;
+    // Copy as many 32-bit chunks as possible.
+    // TODO: Alignment.
+    for (i = 0; i < bytesCopied - 3; i += 4) {
+      target.writeInt32LE(this.readInt32LE(sourceStart + i), targetStart + i);
+    }
+    // Copy any remaining bytes, if applicable
+    for (i = bytesCopied & 0xFFFFFFFC; i < bytesCopied; i++) {
       target.writeUInt8(this.readUInt8(sourceStart + i), targetStart + i);
     }
     return bytesCopied;

--- a/src/generic/key_value_filesystem.ts
+++ b/src/generic/key_value_filesystem.ts
@@ -672,7 +672,7 @@ export class AsyncKeyValueFile extends preload_file.PreloadFile implements file.
         cb(e);
       });
     } else {
-  	  cb();      
+      cb();      
     }
   }
 

--- a/src/generic/key_value_filesystem.ts
+++ b/src/generic/key_value_filesystem.ts
@@ -221,7 +221,10 @@ export class SyncKeyValueFile extends preload_file.PreloadFile implements file.F
   }
 
   public syncSync(): void {
-    (<SyncKeyValueFileSystem> this._fs)._syncSync(this._path, this._buffer, this._stat);
+    if (this.isDirty()) {
+      (<SyncKeyValueFileSystem> this._fs)._syncSync(this.getPath(), this.getBuffer(), this.getStats());
+      this.resetDirty();
+    }
   }
 
   public closeSync(): void {
@@ -661,7 +664,16 @@ export class AsyncKeyValueFile extends preload_file.PreloadFile implements file.
   }
 
   public sync(cb: (e?: api_error.ApiError) => void): void {
-    (<AsyncKeyValueFileSystem> this._fs)._sync(this._path, this._buffer, this._stat, cb);
+    if (this.isDirty()) {
+      (<AsyncKeyValueFileSystem> this._fs)._sync(this.getPath(), this.getBuffer(), this.getStats(), (e?: api_error.ApiError) => {
+        if (!e) {
+          this.resetDirty();
+        }
+        cb(e);
+      });
+    } else {
+  	  cb();      
+    }
   }
 
   public close(cb: (e?: api_error.ApiError) => void): void {

--- a/test/harness/factories/async_mirror_factory.ts
+++ b/test/harness/factories/async_mirror_factory.ts
@@ -1,0 +1,26 @@
+import AsyncMirrorFS = require('../../../src/backend/async_mirror');
+import BackendFactory = require('../BackendFactory');
+import file_system = require('../../../src/core/file_system');
+import in_memory = require('../../../src/backend/in_memory');
+import IDBFSFactory = require('./idbfs_factory');
+
+function AsyncMirrorFactory(cb: (name: string, objs: file_system.FileSystem[]) => void) {
+  IDBFSFactory((name: string, obj: file_system.FileSystem[]) => {
+	 if (obj.length > 0) {
+		 var amfs = new AsyncMirrorFS(new in_memory.InMemoryFileSystem(), obj[0]);
+     amfs.initialize((err?) => {
+       if (err) {
+         throw err;
+       } else {
+         cb('AsyncMirror', [amfs]);
+       }
+     });
+	 } else {
+     cb("AsyncMirror", []);
+	 }
+  });
+}
+
+var _: BackendFactory = AsyncMirrorFactory;
+
+export = AsyncMirrorFactory;

--- a/test/harness/factories/idbfs_factory.ts
+++ b/test/harness/factories/idbfs_factory.ts
@@ -16,7 +16,7 @@ function IDBFSFactory(cb: (name: string, obj: file_system.FileSystem[]) => void)
           }
         });
       }
-    }, 'test');
+    }, 'test' + Math.random());
   } else {
     cb('IndexedDB', []);
   }

--- a/test/harness/factories/overlay_factory.ts
+++ b/test/harness/factories/overlay_factory.ts
@@ -1,0 +1,24 @@
+import OverlayFS = require('../../../src/backend/overlay');
+import BackendFactory = require('../BackendFactory');
+import file_system = require('../../../src/core/file_system');
+import in_memory = require('../../../src/backend/in_memory');
+import ZipFactory = require('./zipfs_factory');
+
+function OverlayFactory(cb: (name: string, objs: file_system.FileSystem[]) => void) {
+  ZipFactory((name: string, obj: file_system.FileSystem[]) => {
+    // Use only one of the given file systems.
+    // Mirror zip changes in in-memory.
+    var ofs = new OverlayFS(new in_memory.InMemoryFileSystem(), obj[0]);
+    ofs.initialize((err?) => {
+      if (err) {
+        throw err;
+      } else {
+        cb('OverlayFS', [ofs]);
+      }
+    });
+  });
+}
+
+var _: BackendFactory = OverlayFactory;
+
+export = OverlayFactory;

--- a/test/harness/setup.ts
+++ b/test/harness/setup.ts
@@ -135,9 +135,6 @@ declare var loadFixtures: Function;
 
       backendFactories.forEach((factory) => {
         factory((name: string, backends) => {
-          if (name !== 'OverlayFS') {
-            backends = [];
-          }
           var backendSemaphore: number = backends.length;
           // XXX: 0 backend case.
           if (backendSemaphore === 0) {

--- a/test/harness/setup.ts
+++ b/test/harness/setup.ts
@@ -135,6 +135,9 @@ declare var loadFixtures: Function;
 
       backendFactories.forEach((factory) => {
         factory((name: string, backends) => {
+          if (name !== 'OverlayFS') {
+            backends = [];
+          }
           var backendSemaphore: number = backends.length;
           // XXX: 0 backend case.
           if (backendSemaphore === 0) {

--- a/test/tests/fs/OverlayFS/persist-test.js
+++ b/test/tests/fs/OverlayFS/persist-test.js
@@ -28,14 +28,14 @@ define([], function() { return function(){
   newCombined.initialize(function() {
     assert(newCombined.existsSync('/test/fixtures/files/node') === false, 'Directory must still be deleted.');
     assert(newCombined.readdirSync('/test/fixtures/files').length === 0, "File system must still be empty.");
-  });
-  
-  var newFs = new BrowserFS.FileSystem.OverlayFS(new BrowserFS.FileSystem.InMemory(), readable);
-  newFs.initialize(function() {
-    BrowserFS.initialize(newFs);
-    assert(fs.existsSync('/test/fixtures/files/node') === true, "Directory must be back");
-    assert(fs.readdirSync('/test/fixtures/files').length > 0, "Directory must be back.");
-    // XXX: Remake the tmpdir.
-    fs.mkdirSync(common.tmpDir);
+    
+    var newFs = new BrowserFS.FileSystem.OverlayFS(new BrowserFS.FileSystem.InMemory(), readable);
+    newFs.initialize(function() {
+      BrowserFS.initialize(newFs);
+      assert(fs.existsSync('/test/fixtures/files/node') === true, "Directory must be back");
+      assert(fs.readdirSync('/test/fixtures/files').length > 0, "Directory must be back.");
+      // XXX: Remake the tmpdir.
+      fs.mkdirSync(common.tmpDir);
+    });
   });
 };});

--- a/test/tests/fs/OverlayFS/persist-test.js
+++ b/test/tests/fs/OverlayFS/persist-test.js
@@ -1,0 +1,39 @@
+/**
+ * Ensures that changes to OverlayFS appropriately persists across instantiations.
+ * Side effect: Discards doubly-loaded files (files are present in ZipFS, but are
+ * accidentally re-written and reloaded by test runner). This is a Good Thing.
+ */
+define([], function() { return function(){
+  if (!(fs.getRootFS() instanceof BrowserFS.FileSystem.OverlayFS)) return;
+  var rootFS = fs.getRootFS(),
+    fses = rootFS.getOverlayedFileSystems(),
+    // XXX: Make these proper API calls.
+    readable = fses.readable,
+    writable = fses.writable;
+  
+  // Ensure no files are doubled.
+  var seenMap = [];
+  fs.readdirSync('/test/fixtures/files/node').forEach(function(file) {
+    assert(seenMap.indexOf(file) === -1, "File " + file + " cannot exist multiple times.");
+    seenMap.push(file);
+    fs.unlinkSync('/test/fixtures/files/node/' + file);
+  });
+  
+  fs.rmdirSync('/test/fixtures/files/node');
+  
+  assert(fs.existsSync('/test/fixtures/files/node') === false, 'Directory must be deleted');
+  assert(fs.readdirSync('/test/fixtures/files').length === 0, 'File system must be empty.');
+  
+  var newCombined = new BrowserFS.FileSystem.OverlayFS(writable, readable);
+  newCombined.initialize(function() {
+    assert(newCombined.existsSync('/test/fixtures/files/node') === false, 'Directory must still be deleted.');
+    assert(newCombined.readdirSync('/test/fixtures/files').length === 0, "File system must still be empty.");
+  });
+  
+  var newFs = new BrowserFS.FileSystem.OverlayFS(new BrowserFS.FileSystem.InMemory(), readable);
+  newFs.initialize(function() {
+    BrowserFS.initialize(newFs);
+    assert(fs.existsSync('/test/fixtures/files/node') === true, "Directory must be back");
+    assert(fs.readdirSync('/test/fixtures/files').length > 0, "Directory must be back.");
+  });
+};});

--- a/test/tests/fs/OverlayFS/persist-test.js
+++ b/test/tests/fs/OverlayFS/persist-test.js
@@ -35,5 +35,7 @@ define([], function() { return function(){
     BrowserFS.initialize(newFs);
     assert(fs.existsSync('/test/fixtures/files/node') === true, "Directory must be back");
     assert(fs.readdirSync('/test/fixtures/files').length > 0, "Directory must be back.");
+    // XXX: Remake the tmpdir.
+    fs.mkdirSync(common.tmpDir);
   });
 };});

--- a/test/tests/fs/all/node-fs-stat.js
+++ b/test/tests/fs/all/node-fs-stat.js
@@ -78,9 +78,6 @@ if (fs.getRootFS().supportsSynch()) {
       got_error = true;
     }
     if (stats) {
-      // BFS: IE9 doesn't define console until you open dev tools, so this
-      // fails.
-      if (console['dir']) console.dir(stats);
       assert.ok(stats.mtime instanceof Date);
       success_count++;
     }

--- a/test/tests/fs/all/rename-test.js
+++ b/test/tests/fs/all/rename-test.js
@@ -177,14 +177,18 @@ define([], function() { return function(){
         if (e == null) {
           throw new Error("Failed invariant: Cannot rename a file over an existing directory.");
         } else {
-          // it's a permissions error for some reason (tested in node).
-          assert(e.code === 'EPERM');
+          // Some *native* file systems throw EISDIR, others throw EPERM.... accept both.
+          assert(e.code === 'EISDIR' || e.code === 'EPERM');
         }
-        fs.rename(dir, file, function (e) {
-          if (e) {
-            throw new Error("Failed invariant: Can rename a directory over a file.");
+        // JV: Removing test for now. I noticed that you can do that in Node v0.12 on Mac,
+        // but it might be FS independent.
+        /*fs.rename(dir, file, function (e) {
+          if (e == null) {
+            throw new Error("Failed invariant: Cannot rename a directory over a file.");
+          } else {
+            assert(e.code === 'ENOTDIR');
           }
-        });
+        });*/
       });
     });
   });


### PR DESCRIPTION
OverlayFS:
* Lets you overlay a *writable* synchronous file system over a *readable* synchronous file system. Writes to any file are written only to the writable file system.
  * Most common use case: Marry a ZipFS with an InMemoryFS to let applications write to files in zip files.
  * You can also OverlayFS a MountableFileSystem that contains multiple ZipFSs mounted inside. Go nuts!

AsyncMirror:
* Lets you mirror a synchronous FS to an asynchronous FS.
  * Most common use case: Marry an InMemory file system to any large asynchronous data storage (e.g. IndexedDB) to enable apps to persist data to async storage. Note that all files in that async storage will need to be preloaded into the InMemory file system through AsyncMirror's `initialize` method.

If you AsyncMirror the writable portion of an OverlayFS, then you can persist changed files from a zip file. This is ideal for something like the Internet Archive's MS-DOS collection, which contains many applications in zip files that modify themselves.

Optimizations:
* Buffer's copy method now copies data in 4-byte increments.
* PreloadFile now tracks a dirty bit to prevent syncing when file has not been changed. This was important for OverlayFS. :)