### PR TITLE
build: pin grunt-karma to 0.11.X to avoid npm sadness

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "grunt-contrib-uglify": "~0.9.1",
     "grunt-contrib-watch": "*",
     "grunt-exorcise": "~2.0.0",
-    "grunt-karma": "latest",
+    "grunt-karma": "~0.11.0",
     "grunt-shell": "~0.5.0",
     "karma": "^0.12.36",
     "karma-browserify": "^4.2.1",


### PR DESCRIPTION
Latest currently results in this:

npm ERR! peerinvalid The package karma@0.12.37 does not satisfy its siblings' peerDependencies requirements!
npm ERR! peerinvalid Peer karma-mocha@0.1.10 wants karma@>=0.12.8
npm ERR! peerinvalid Peer karma-safari-launcher@0.1.1 wants karma@>=0.9
npm ERR! peerinvalid Peer karma-opera-launcher@0.3.0 wants karma@>=0.9
npm ERR! peerinvalid Peer grunt-karma@0.12.1 wants karma@^0.13.0 || >= 0.14.0-rc.0
npm ERR! peerinvalid Peer karma-browserify@4.3.0 wants karma@>=0.10