### PR TITLE
faster implementation of index.addPath() and async ZipFS

### DIFF
--- a/src/backend/AsyncZipFS.ts
+++ b/src/backend/AsyncZipFS.ts
@@ -1,0 +1,219 @@
+/**
+ * AsyncZipFS is a more responsive version of ZipFS. The thread yields more often during indexing.
+ * One more difference is that querying the central directory in the zip file is not supported in AsyncZipFS.
+ *
+ * Example usage:
+ *
+ * if the original ZipFS code is:
+ *
+ *   new ZipFS(data, name);
+ *
+ * then the equivalent AsyncZipFS code would be:
+ *
+ *   AsyncZipFS.computeIndex(data, (index) => {
+ *     new AsyncZipFS(index, name);
+ *   });
+ */
+
+import {ApiError, ErrorCode} from '../core/api_error';
+import {default as Stats, FileType} from '../core/node_fs_stats';
+import file_system = require('../core/file_system');
+import file = require('../core/file');
+import {FileFlag, ActionType} from '../core/file_flag';
+import preload_file = require('../generic/preload_file');
+import {Arrayish, buffer2Arrayish, arrayish2Buffer, copyingSlice} from '../core/util';
+import ExtendedASCII from 'bfs-buffer/js/extended_ascii';
+
+import {CentralDirectory, EndOfCentralDirectory} from './ZipFS';
+
+var inflateRaw: {
+  (data: Arrayish<number>, options?: {
+    chunkSize: number;
+  }): Arrayish<number>;
+} = require('pako/dist/pako_inflate.min').inflateRaw;
+import {FileIndex, DirInode, FileInode, isDirInode, isFileInode} from '../generic/file_index';
+
+
+export default class AsyncZipFS extends file_system.SynchronousFileSystem implements file_system.FileSystem {
+  /**
+   * Constructs a ZipFS from the given zip file data. Name is optional, and is
+   * used primarily for our unit tests' purposes to differentiate different
+   * test zip files in test output.
+   */
+  constructor(private _index: FileIndex<CentralDirectory>, private name: string = '') {
+    super();
+  }
+
+  public getName(): string {
+    return 'ZipFS' + (this.name !== '' ? ' ' + this.name : '');
+  }
+
+  public static isAvailable(): boolean { return true; }
+
+  public diskSpace(path: string, cb: (total: number, free: number) => void): void {
+    // Read-only file system.
+    // cb(this.data.length, 0);
+    // TODO
+    cb(0, 0);
+  }
+
+  public isReadOnly(): boolean {
+    return true;
+  }
+
+  public supportsLinks(): boolean {
+    return false;
+  }
+
+  public supportsProps(): boolean {
+    return false;
+  }
+
+  public supportsSynch(): boolean {
+    return true;
+  }
+
+  public statSync(path: string, isLstat: boolean): Stats {
+    var inode = this._index.getInode(path);
+    if (inode === null) {
+      throw ApiError.ENOENT(path);
+    }
+    var stats: Stats;
+    if (isFileInode<CentralDirectory>(inode)) {
+      stats = inode.getData().getStats();
+    } else if (isDirInode(inode)) {
+      stats = inode.getStats();
+    } else {
+      throw new ApiError(ErrorCode.EINVAL, "Invalid inode.");
+    }
+    return stats;
+  }
+
+  public openSync(path: string, flags: FileFlag, mode: number): file.File {
+    // INVARIANT: Cannot write to RO file systems.
+    if (flags.isWriteable()) {
+      throw new ApiError(ErrorCode.EPERM, path);
+    }
+    // Check if the path exists, and is a file.
+    var inode = this._index.getInode(path);
+    if (!inode) {
+      throw ApiError.ENOENT(path);
+    } else if (isFileInode<CentralDirectory>(inode)) {
+      var cdRecord = inode.getData();
+      var stats = cdRecord.getStats();
+      switch (flags.pathExistsAction()) {
+        case ActionType.THROW_EXCEPTION:
+        case ActionType.TRUNCATE_FILE:
+          throw ApiError.EEXIST(path);
+        case ActionType.NOP:
+          return new preload_file.NoSyncFile(this, path, flags, stats, cdRecord.getData());
+        default:
+          throw new ApiError(ErrorCode.EINVAL, 'Invalid FileMode object.');
+      }
+      return null;
+    } else {
+      throw ApiError.EISDIR(path);
+    }
+  }
+
+  public readdirSync(path: string): string[] {
+    // Check if it exists.
+    var inode = this._index.getInode(path);
+    if (!inode) {
+      throw ApiError.ENOENT(path);
+    } else if (isDirInode(inode)) {
+      return inode.getListing();
+    } else {
+      throw ApiError.ENOTDIR(path);
+    }
+  }
+
+  /**
+   * Specially-optimized readfile.
+   */
+  public readFileSync(fname: string, encoding: string, flag: FileFlag): any {
+    // Get file.
+    var fd = this.openSync(fname, flag, 0x1a4);
+    try {
+      var fdCast = <preload_file.NoSyncFile<AsyncZipFS>> fd;
+      var fdBuff = <Buffer> fdCast.getBuffer();
+      if (encoding === null) {
+        return copyingSlice(fdBuff);
+      }
+      return fdBuff.toString(encoding);
+    } finally {
+      fd.closeSync();
+    }
+  }
+
+  /**
+   * Locates the end of central directory record at the end of the file.
+   * Throws an exception if it cannot be found.
+   */
+  private static getEOCD(data: NodeBuffer): EndOfCentralDirectory {
+    // Unfortunately, the comment is variable size and up to 64K in size.
+    // We assume that the magic signature does not appear in the comment, and
+    // in the bytes between the comment and the signature. Other ZIP
+    // implementations make this same assumption, since the alternative is to
+    // read thread every entry in the file to get to it. :(
+    // These are *negative* offsets from the end of the file.
+    var startOffset = 22;
+    var endOffset = Math.min(startOffset + 0xFFFF, data.length - 1);
+    // There's not even a byte alignment guarantee on the comment so we need to
+    // search byte by byte. *grumble grumble*
+    for (var i = startOffset; i < endOffset; i++) {
+      // Magic number: EOCD Signature
+      if (data.readUInt32LE(data.length - i) === 0x06054b50) {
+        return new EndOfCentralDirectory(data.slice(data.length - i));
+      }
+    }
+    throw new ApiError(ErrorCode.EINVAL, "Invalid ZIP file: Could not locate End of Central Directory signature.");
+  }
+
+  private static addToIndex(cd: CentralDirectory, index: FileIndex<CentralDirectory>) {
+    // Paths must be absolute, yet zip file paths are always relative to the
+    // zip root. So we append '/' and call it a day.
+    let filename = cd.fileName();
+    if (filename.charAt(0) === '/') throw new Error("WHY IS THIS ABSOLUTE");
+    // XXX: For the file index, strip the trailing '/'.
+    if (filename.charAt(filename.length - 1) === '/') {
+      filename = filename.substr(0, filename.length-1);
+    }
+
+    if (cd.isDirectory()) {
+      index.addPathFast('/' + filename, new DirInode<CentralDirectory>(cd));
+    } else {
+      index.addPathFast('/' + filename, new FileInode<CentralDirectory>(cd));
+    }
+  }
+
+  static computeIndexResponsive(data: NodeBuffer, index: FileIndex<CentralDirectory>, cdPtr: number, cdEnd: number, cb: (index: FileIndex<CentralDirectory>) => void) {
+    if (cdPtr < cdEnd) {
+      let count = 0;
+      while (count++ < 200 && cdPtr < cdEnd) {
+        const cd: CentralDirectory = new CentralDirectory(data, data.slice(cdPtr));
+        AsyncZipFS.addToIndex(cd, index);
+        cdPtr += cd.totalSize();
+      }
+      setImmediate(() => {
+        AsyncZipFS.computeIndexResponsive(data, index, cdPtr, cdEnd, cb);
+      });
+    } else {
+      console.log("done", cdPtr);
+      cb(index);
+    }
+  }
+
+  static computeIndex(data: NodeBuffer, cb: (index: FileIndex<CentralDirectory>) => void) {
+    const index: FileIndex<CentralDirectory> = new FileIndex<CentralDirectory>();
+    const eocd: EndOfCentralDirectory = AsyncZipFS.getEOCD(data);
+    if (eocd.diskNumber() !== eocd.cdDiskNumber())
+      throw new ApiError(ErrorCode.EINVAL, "ZipFS does not support spanned zip files.");
+
+    const cdPtr = eocd.cdOffset();
+    if (cdPtr === 0xFFFFFFFF)
+      throw new ApiError(ErrorCode.EINVAL, "ZipFS does not support Zip64.");
+    const cdEnd = cdPtr + eocd.cdSize();
+    AsyncZipFS.computeIndexResponsive(data, index, cdPtr, cdEnd, cb);
+  }
+}

--- a/src/backend/ZipFS.ts
+++ b/src/backend/ZipFS.ts
@@ -680,20 +680,21 @@ export default class ZipFS extends file_system.SynchronousFileSystem implements 
       throw new ApiError(ErrorCode.EINVAL, "ZipFS does not support Zip64.");
     var cdEnd = cdPtr + eocd.cdSize();
     while (cdPtr < cdEnd) {
-      var cd: CentralDirectory = new CentralDirectory(this.data, this.data.slice(cdPtr));
+      const cd: CentralDirectory = new CentralDirectory(this.data, this.data.slice(cdPtr));
       cdPtr += cd.totalSize();
       // Paths must be absolute, yet zip file paths are always relative to the
       // zip root. So we append '/' and call it a day.
-      var filename = cd.fileName();
+      let filename = cd.fileName();
       if (filename.charAt(0) === '/') throw new Error("WHY IS THIS ABSOLUTE");
       // XXX: For the file index, strip the trailing '/'.
       if (filename.charAt(filename.length - 1) === '/') {
         filename = filename.substr(0, filename.length-1);
       }
+
       if (cd.isDirectory()) {
-        this._index.addPath('/' + filename, new DirInode<CentralDirectory>(cd));
+        this._index.addPathFast('/' + filename, new DirInode<CentralDirectory>(cd));
       } else {
-        this._index.addPath('/' + filename, new FileInode<CentralDirectory>(cd));
+        this._index.addPathFast('/' + filename, new FileInode<CentralDirectory>(cd));
       }
       this._directoryEntries.push(cd);
     }

--- a/src/generic/file_index.ts
+++ b/src/generic/file_index.ts
@@ -111,11 +111,11 @@ export class FileIndex<T> {
    * @todo If adding fails and implicitly creates directories, we do not clean up
    *   the new empty directories.
    */
-  public addPathFast(filename: string, inode: Inode): boolean {
+  public addPathFast(path: string, inode: Inode): boolean {
 
-    const itemNameMark = filename.lastIndexOf('/');
-    const parentPath = itemNameMark == 0 ? "/" : filename.substring(0, itemNameMark);
-    const itemName = filename.substring(itemNameMark+1);
+    const itemNameMark = path.lastIndexOf('/');
+    const parentPath = itemNameMark == 0 ? "/" : path.substring(0, itemNameMark);
+    const itemName = path.substring(itemNameMark+1);
 
     // Try to add to its parent directory first.
     let parent = this._index[parentPath];

--- a/src/generic/file_index.ts
+++ b/src/generic/file_index.ts
@@ -131,7 +131,7 @@ export class FileIndex<T> {
 
     // If adding a directory, add to the index as well.
     if (inode.isDir()) {
-      this._index[parentPath + "/" + itemName] = <DirInode<T>> inode;
+      this._index[path] = <DirInode<T>> inode;
     }
     return true;
   }

--- a/src/generic/file_index.ts
+++ b/src/generic/file_index.ts
@@ -99,6 +99,44 @@ export class FileIndex<T> {
   }
 
   /**
+   * Adds the given absolute path to the index if it is not already in the index.
+   * The path is added without special treatment (no joining of adjacent separators, etc).
+   * Creates any needed parent directories.
+   * @param [String] path The path to add to the index.
+   * @param [BrowserFS.FileInode | BrowserFS.DirInode] inode The inode for the
+   *   path to add.
+   * @return [Boolean] 'True' if it was added or already exists, 'false' if there
+   *   was an issue adding it (e.g. item in path is a file, item exists but is
+   *   different).
+   * @todo If adding fails and implicitly creates directories, we do not clean up
+   *   the new empty directories.
+   */
+  public addPathFast(filename: string, inode: Inode): boolean {
+
+    const itemNameMark = filename.lastIndexOf('/');
+    const parentPath = itemNameMark == 0 ? "/" : filename.substring(0, itemNameMark);
+    const itemName = filename.substring(itemNameMark+1);
+
+    // Try to add to its parent directory first.
+    let parent = this._index[parentPath];
+    if (parent === undefined) {
+      // Create parent.
+      parent = new DirInode<T>();
+      this.addPathFast(parentPath, parent);
+    }
+
+    if (!parent.addItem(itemName, inode)) {
+      return false;
+    }
+
+    // If adding a directory, add to the index as well.
+    if (inode.isDir()) {
+      this._index[parentPath + "/" + itemName] = <DirInode<T>> inode;
+    }
+    return true;
+  }
+
+  /**
    * Removes the given path. Can be a file or a directory.
    * @return [BrowserFS.FileInode | BrowserFS.DirInode | null] The removed item,
    *   or null if it did not exist.


### PR DESCRIPTION
### Background
I have been profiling BFS, and there are two critical paths which block the JS thread:
* `readFile('rt.jar')`, which eventually calls `ArrayBuffer.slice()`. Since `rt.jar` is about 60MB, the copying blocks the CPU for a long time, followed by a major GC cycle.
* `new ZipFS()` of `rt.jar`, which indexes the files within the jar (about 19k files).

This PR is an attempt to reduce the time taken by latter. The time to index is reduced from 245ms to ~~191ms~~ 184ms (taking the best runs of each).

### Changes
A new variant of `addPath()` has been added called `addPathFast()`. The main difference is that it uses `string.lastIndexOf(/)` to derive the basename and filename from the path. Whereas the original version uses `path.dirname()` which is slow, because it does more.

Please let me know if this approach is fine. 