### PR TITLE
backend/overlay: add async support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+
+[*.{js,ts}]
+indent_style = space
+indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 doc
+*~
 *.DS_Store
 *.log
 *.json

--- a/src/backend/AsyncMirror.ts
+++ b/src/backend/AsyncMirror.ts
@@ -4,6 +4,7 @@ import file_flag = require('../core/file_flag');
 import file = require('../core/file');
 import Stats from '../core/node_fs_stats';
 import preload_file = require('../generic/preload_file');
+import * as path from 'path';
 
 interface IAsyncOperation {
 	apiMethod: string;
@@ -106,7 +107,7 @@ export default class AsyncMirror extends file_system.SynchronousFileSystem imple
                 if (err) {
                   cb(err);
                 } else if (i < files.length) {
-                  copyItem(`${p}/${files[i]}`, copyNextFile);
+                  copyItem(path.join(p, files[i]), copyNextFile);
                   i++;
                 } else {
                   cb();

--- a/src/backend/OverlayFS.ts
+++ b/src/backend/OverlayFS.ts
@@ -240,6 +240,7 @@ export class UnlockedOverlayFS extends file_system.SynchronousFileSystem impleme
   }
 
   public rename(oldPath: string, newPath: string, cb: (err?: ApiError) => void): void {
+    this.checkInitialized();
     // nothing to do if paths match
     if (oldPath === newPath) {
       return cb();
@@ -399,6 +400,7 @@ export class UnlockedOverlayFS extends file_system.SynchronousFileSystem impleme
   }
 
   public stat(p: string, isLstat: boolean,  cb: (err: ApiError, stat?: Stats) => void): void {
+    this.checkInitialized();
     this._writable.stat(p, isLstat, (err: ApiError, stat?: Stats) => {
       if (err && err.errno === ErrorCode.ENOENT) {
         if (this._deletedFiles[p]) {
@@ -437,6 +439,7 @@ export class UnlockedOverlayFS extends file_system.SynchronousFileSystem impleme
   }
 
   public open(p: string, flag: FileFlag, mode: number, cb: (err: ApiError, fd?: File) => any): void {
+    this.checkInitialized();
     this.stat(p, false, (err: ApiError, stats?: Stats) => {
       if (stats) {
         switch (flag.pathExistsAction()) {
@@ -518,6 +521,7 @@ export class UnlockedOverlayFS extends file_system.SynchronousFileSystem impleme
   }
 
   public unlink(p: string, cb: (err: ApiError) => void): void {
+    this.checkInitialized();
     this.exists(p, (exists: boolean) => {
       if (!exists)
         return cb(ApiError.ENOENT(p));
@@ -563,6 +567,7 @@ export class UnlockedOverlayFS extends file_system.SynchronousFileSystem impleme
   }
 
   public rmdir(p: string, cb: (err?: ApiError) => void): void {
+    this.checkInitialized();
 
     let rmdirLower = (): void => {
       this.readdir(p, (err: ApiError, files: string[]): void => {
@@ -626,6 +631,7 @@ export class UnlockedOverlayFS extends file_system.SynchronousFileSystem impleme
   }
 
   public mkdir(p: string, mode: number, cb: (err: ApiError, stat?: Stats) => void): void {
+    this.checkInitialized();
     this.exists(p, (exists: boolean) => {
       if (exists) {
         return cb(ApiError.EEXIST(p));
@@ -655,6 +661,7 @@ export class UnlockedOverlayFS extends file_system.SynchronousFileSystem impleme
   }
 
   public readdir(p: string, cb: (error: ApiError, files?: string[]) => void): void {
+    this.checkInitialized();
     this.stat(p, false, (err: ApiError, dirStats?: Stats) => {
       if (err) {
         return cb(err);
@@ -719,6 +726,7 @@ export class UnlockedOverlayFS extends file_system.SynchronousFileSystem impleme
   }
 
   public exists(p: string, cb: (exists: boolean) => void): void {
+    this.checkInitialized();
     this._writable.exists(p, (existsWritable: boolean) => {
       if (existsWritable) {
         return cb(true);
@@ -736,6 +744,7 @@ export class UnlockedOverlayFS extends file_system.SynchronousFileSystem impleme
   }
 
   public chmod(p: string, isLchmod: boolean, mode: number, cb: (error?: ApiError) => void): void {
+    this.checkInitialized();
     this.operateOnWritableAsync(p, (err?: ApiError) => {
       if (err) {
         return cb(err);
@@ -753,6 +762,7 @@ export class UnlockedOverlayFS extends file_system.SynchronousFileSystem impleme
   }
 
   public chown(p: string, isLchmod: boolean, uid: number, gid: number, cb: (error?: ApiError) => void): void {
+    this.checkInitialized();
     this.operateOnWritableAsync(p, (err?: ApiError) => {
       if (err) {
         return cb(err);
@@ -770,6 +780,7 @@ export class UnlockedOverlayFS extends file_system.SynchronousFileSystem impleme
   }
 
   public utimes(p: string, atime: Date, mtime: Date, cb: (error?: ApiError) => void): void {
+    this.checkInitialized();
     this.operateOnWritableAsync(p, (err?: ApiError) => {
       if (err) {
         return cb(err);

--- a/src/backend/OverlayFS.ts
+++ b/src/backend/OverlayFS.ts
@@ -5,7 +5,7 @@ import util = require('../core/util');
 import {File} from '../core/file';
 import {default as Stats, FileType} from '../core/node_fs_stats';
 import {PreloadFile} from '../generic/preload_file';
-import {LockedFS} from '../generic/locked_fs';
+import LockedFS from '../generic/locked_fs';
 import path = require('path');
 let deletionLogPath = '/.deletedFiles.log';
 

--- a/src/backend/OverlayFS.ts
+++ b/src/backend/OverlayFS.ts
@@ -868,7 +868,7 @@ export class UnlockedOverlayFS extends BaseFileSystem implements FileSystem {
 
 export default class OverlayFS extends LockedFS<UnlockedOverlayFS> {
 	constructor(writable: FileSystem, readable: FileSystem) {
-		super(UnlockedOverlayFS, writable, readable);
+		super(new UnlockedOverlayFS(writable, readable));
 	}
 
 	initialize(cb: (err?: ApiError) => void): void {

--- a/src/backend/OverlayFS.ts
+++ b/src/backend/OverlayFS.ts
@@ -4,7 +4,8 @@ import {FileFlag, ActionType} from '../core/file_flag';
 import util = require('../core/util');
 import file = require('../core/file');
 import Stats from '../core/node_fs_stats';
-import preload_file = require('../generic/preload_file');
+import {PreloadFile} from '../generic/preload_file';
+import {LockedFS} from '../generic/locked_fs';
 import path = require('path');
 let deletionLogPath = '/.deletedFiles.log';
 
@@ -22,8 +23,8 @@ function getFlag(f: string): FileFlag {
 /**
  * Overlays a RO file to make it writable.
  */
-class OverlayFile extends preload_file.PreloadFile<OverlayFS> implements file.File {
-  constructor(fs: OverlayFS, path: string, flag: FileFlag, stats: Stats, data: Buffer) {
+class OverlayFile extends PreloadFile<UnlockedOverlayFS> implements file.File {
+  constructor(fs: UnlockedOverlayFS, path: string, flag: FileFlag, stats: Stats, data: Buffer) {
     super(fs, path, flag, stats, data);
   }
 
@@ -60,7 +61,7 @@ class OverlayFile extends preload_file.PreloadFile<OverlayFS> implements file.Fi
  * writable file system. Deletes are persisted via metadata stored on the writable
  * file system.
  */
-export default class OverlayFS extends file_system.SynchronousFileSystem implements file_system.FileSystem {
+export class UnlockedOverlayFS extends file_system.SynchronousFileSystem implements file_system.FileSystem {
   private _writable: file_system.FileSystem;
   private _readable: file_system.FileSystem;
   private _isInitialized: boolean = false;
@@ -145,13 +146,13 @@ export default class OverlayFS extends file_system.SynchronousFileSystem impleme
     return true;
   }
 
-  public _syncAsync(file: preload_file.PreloadFile<OverlayFS>, cb: (err: ApiError)=>void): void {
+  public _syncAsync(file: PreloadFile<UnlockedOverlayFS>, cb: (err: ApiError)=>void): void {
     this.createParentDirectoriesAsync(file.getPath(), () => {
       this._writable.writeFile(file.getPath(), file.getBuffer(), null, getFlag('w'), file.getStats().mode, cb);
     });
   }
 
-  public _syncSync(file: preload_file.PreloadFile<OverlayFS>): void {
+  public _syncSync(file: PreloadFile<UnlockedOverlayFS>): void {
     this.createParentDirectories(file.getPath());
     this._writable.writeFileSync(file.getPath(), file.getBuffer(), null, getFlag('w'), file.getStats().mode);
   }
@@ -446,4 +447,22 @@ export default class OverlayFS extends file_system.SynchronousFileSystem impleme
         getFlag('w'), this.statSync(p, false).mode);
     }
   }
+}
+
+export default class OverlayFS extends LockedFS<UnlockedOverlayFS> {
+	constructor(writable: file_system.FileSystem, readable: file_system.FileSystem) {
+		super(UnlockedOverlayFS, writable, readable);
+	}
+
+	initialize(cb: (err?: ApiError) => void): void {
+		super.initialize(cb);
+	}
+
+	static isAvailable(): boolean {
+		return UnlockedOverlayFS.isAvailable();
+	}
+
+	getOverlayedFileSystems(): { readable: file_system.FileSystem; writable: file_system.FileSystem; } {
+		return super.getFSUnlocked().getOverlayedFileSystems();
+	}
 }

--- a/src/backend/OverlayFS.ts
+++ b/src/backend/OverlayFS.ts
@@ -68,7 +68,6 @@ export class UnlockedOverlayFS extends file_system.SynchronousFileSystem impleme
   private _initializeCallbacks: ((e?: ApiError) => void)[] = [];
   private _deletedFiles: {[path: string]: boolean} = {};
   private _deleteLog: File = null;
-  private _isAsync: boolean;
 
   constructor(writable: file_system.FileSystem, readable: file_system.FileSystem) {
     super();
@@ -77,7 +76,6 @@ export class UnlockedOverlayFS extends file_system.SynchronousFileSystem impleme
     if (this._writable.isReadOnly()) {
       throw new ApiError(ErrorCode.EINVAL, "Writable file system must be writable.");
     }
-    this._isAsync = !this._writable.supportsSynch() || !this._readable.supportsSynch();
   }
 
   private checkInitialized(): void {
@@ -219,7 +217,7 @@ export class UnlockedOverlayFS extends file_system.SynchronousFileSystem impleme
   }
 
   public isReadOnly(): boolean { return false; }
-  public supportsSynch(): boolean { return true; }
+  public supportsSynch(): boolean { return this._readable.supportsSynch() && this._writable.supportsSynch(); }
   public supportsLinks(): boolean { return false; }
   public supportsProps(): boolean { return this._readable.supportsProps() && this._writable.supportsProps(); }
 

--- a/src/backend/OverlayFS.ts
+++ b/src/backend/OverlayFS.ts
@@ -1,4 +1,4 @@
-import file_system = require('../core/file_system');
+import {FileSystem, BaseFileSystem} from '../core/file_system';
 import {ApiError, ErrorCode} from '../core/api_error';
 import {FileFlag, ActionType} from '../core/file_flag';
 import util = require('../core/util');
@@ -61,15 +61,15 @@ class OverlayFile extends PreloadFile<UnlockedOverlayFS> implements File {
  * writable file system. Deletes are persisted via metadata stored on the writable
  * file system.
  */
-export class UnlockedOverlayFS extends file_system.SynchronousFileSystem implements file_system.FileSystem {
-  private _writable: file_system.FileSystem;
-  private _readable: file_system.FileSystem;
+export class UnlockedOverlayFS extends BaseFileSystem implements FileSystem {
+  private _writable: FileSystem;
+  private _readable: FileSystem;
   private _isInitialized: boolean = false;
   private _initializeCallbacks: ((e?: ApiError) => void)[] = [];
   private _deletedFiles: {[path: string]: boolean} = {};
   private _deleteLog: File = null;
 
-  constructor(writable: file_system.FileSystem, readable: file_system.FileSystem) {
+  constructor(writable: FileSystem, readable: FileSystem) {
     super();
     this._writable = writable;
     this._readable = readable;
@@ -84,7 +84,7 @@ export class UnlockedOverlayFS extends file_system.SynchronousFileSystem impleme
     }
   }
 
-  public getOverlayedFileSystems(): { readable: file_system.FileSystem; writable: file_system.FileSystem; } {
+  public getOverlayedFileSystems(): { readable: FileSystem; writable: FileSystem; } {
     return {
       readable: this._readable,
       writable: this._writable
@@ -867,7 +867,7 @@ export class UnlockedOverlayFS extends file_system.SynchronousFileSystem impleme
 }
 
 export default class OverlayFS extends LockedFS<UnlockedOverlayFS> {
-	constructor(writable: file_system.FileSystem, readable: file_system.FileSystem) {
+	constructor(writable: FileSystem, readable: FileSystem) {
 		super(UnlockedOverlayFS, writable, readable);
 	}
 
@@ -879,7 +879,7 @@ export default class OverlayFS extends LockedFS<UnlockedOverlayFS> {
 		return UnlockedOverlayFS.isAvailable();
 	}
 
-	getOverlayedFileSystems(): { readable: file_system.FileSystem; writable: file_system.FileSystem; } {
+	getOverlayedFileSystems(): { readable: FileSystem; writable: FileSystem; } {
 		return super.getFSUnlocked().getOverlayedFileSystems();
 	}
 }

--- a/src/backend/OverlayFS.ts
+++ b/src/backend/OverlayFS.ts
@@ -436,6 +436,8 @@ export class UnlockedOverlayFS extends file_system.SynchronousFileSystem impleme
               this._readable.readFile(p, null, getFlag('r'), (readFileErr: ApiError, data?: any) => {
                 if (readFileErr)
                   return cb(readFileErr);
+                if (stats.size === -1)
+                  stats.size = data.length;
                 let f = new OverlayFile(this, p, flag, stats, data);
                 cb(null, f);
               });

--- a/src/generic/locked_fs.ts
+++ b/src/generic/locked_fs.ts
@@ -1,0 +1,392 @@
+import {Mutex} from './mutex';
+import {FileSystem, SynchronousFileSystem} from '../core/file_system';
+import {ApiError, ErrorCode} from '../core/api_error';
+import {FileFlag, ActionType} from '../core/file_flag';
+import {default as Stats, FileType} from '../core/node_fs_stats';
+import {File} from '../core/file';
+
+// TODO: also implement LockedFile to ensure that operations on files
+// also grab the appropriate locks.
+/*
+export LockedFile<T extends File> implements File {
+  private _file: File;
+  private _mu: Mutex;
+
+  constructor(mu: Mutex, f: File) {
+    this._file = f;
+    this._mu = mu;
+  }
+
+  getPos(): number;
+
+  stat(cb: (err: ApiError, stats?: Stats) => any): void;
+
+  statSync(): Stats;
+
+  close(cb: Function): void;
+
+  closeSync(): void;
+
+  truncate(len: number, cb: Function): void;
+
+  truncateSync(len: number): void;
+
+  sync(cb: (e?: ApiError) => void): void;
+
+  syncSync(): void;
+
+  write(buffer: NodeBuffer, offset: number, length: number, position: number, cb: (err: ApiError, written?: number, buffer?: NodeBuffer) => any): void;
+
+  writeSync(buffer: NodeBuffer, offset: number, length: number, position: number): number;
+
+  read(buffer: NodeBuffer, offset: number, length: number, position: number, cb: (err: ApiError, bytesRead?: number, buffer?: NodeBuffer) => void): void;
+
+  readSync(buffer: NodeBuffer, offset: number, length: number, position: number): number;
+
+  datasync(cb: (e?: ApiError) => void): void;
+
+  datasyncSync(): void;
+
+  chown(uid: number, gid: number, cb: (e?: ApiError) => void): void;
+
+  chownSync(uid: number, gid: number): void;
+
+  chmod(mode: number, cb: (e?: ApiError) => void): void;
+
+  chmodSync(mode: number): void;
+
+  utimes(atime: Date, mtime: Date, cb: (e?: ApiError) => void): void;
+
+  utimesSync(atime: Date, mtime: Date): void;
+}
+*/
+
+/// This class serializes access to an underlying async filesystem.
+export class LockedFS<T extends FileSystem> implements FileSystem {
+  private _fs: T;
+  private _mu: Mutex;
+
+  constructor(cls: {new(...args: any[]): T}, ...args: any[]) {
+    this._fs = new (Function.prototype.bind.apply(cls, [null].concat(args)));
+    this._mu = new Mutex();
+  }
+
+  getName(): string {
+    return 'LockedFS<' + this._fs.getName()  + '>';
+  }
+
+  getFSUnlocked(): T {
+    return this._fs;
+  }
+
+  initialize(cb: (err?: ApiError) => void): void {
+    // FIXME: check to see if FS supports initialization
+    (<any>this._fs).initialize(cb);
+  }
+
+  diskSpace(p: string, cb: (total: number, free: number) => any): void {
+    // FIXME: should this lock?
+    this._fs.diskSpace(p, cb);
+  }
+
+  isReadOnly(): boolean {
+    return this._fs.isReadOnly();
+  }
+
+  supportsLinks(): boolean {
+    return this._fs.supportsLinks();
+  }
+
+  supportsProps(): boolean {
+    return this._fs.supportsProps();
+  }
+
+  supportsSynch(): boolean {
+    return this._fs.supportsSynch();
+  }
+
+  rename(oldPath: string, newPath: string, cb: (err?: ApiError) => void): void {
+    this._mu.lock(() => {
+      this._fs.rename(oldPath, newPath, (err?: ApiError) => {
+        this._mu.unlock();
+        cb(err);
+      });
+    });
+  }
+
+  renameSync(oldPath: string, newPath: string): void {
+    if (this._mu.isLocked())
+      throw new Error('invalid sync call');
+    return this._fs.renameSync(oldPath, newPath);
+  }
+
+  stat(p: string, isLstat: boolean, cb: (err: ApiError, stat?: Stats) => void): void {
+    this._mu.lock(() => {
+      this._fs.stat(p, isLstat, (err?: ApiError, stat?: Stats) => {
+        this._mu.unlock();
+        cb(err, stat);
+      });
+    });
+  }
+
+  statSync(p: string, isLstat: boolean): Stats {
+    if (this._mu.isLocked())
+      throw new Error('invalid sync call');
+    return this._fs.statSync(p, isLstat);
+  }
+
+  open(p: string, flag: FileFlag, mode: number, cb: (err: ApiError, fd?: File) => any): void {
+    this._mu.lock(() => {
+      this._fs.open(p, flag, mode, (err?: ApiError, fd?: File) => {
+        this._mu.unlock();
+        cb(err, fd);
+      });
+    });
+  }
+
+  openSync(p: string, flag: FileFlag, mode: number): File {
+    if (this._mu.isLocked())
+      throw new Error('invalid sync call');
+    return this._fs.openSync(p, flag, mode);
+  }
+
+  unlink(p: string, cb: Function): void {
+    this._mu.lock(() => {
+      this._fs.unlink(p, (err?: ApiError) => {
+        this._mu.unlock();
+        cb(err);
+      });
+    });
+  }
+
+  unlinkSync(p: string): void {
+    if (this._mu.isLocked())
+      throw new Error('invalid sync call');
+    return this._fs.unlinkSync(p);
+  }
+
+  rmdir(p: string, cb: Function): void {
+    this._mu.lock(() => {
+      this._fs.rmdir(p, (err?: ApiError) => {
+        this._mu.unlock();
+        cb(err);
+      });
+    });
+  }
+
+  rmdirSync(p: string): void {
+    if (this._mu.isLocked())
+      throw new Error('invalid sync call');
+    return this._fs.rmdirSync(p);
+  }
+
+  mkdir(p: string, mode: number, cb: Function): void {
+    this._mu.lock(() => {
+      this._fs.mkdir(p, mode, (err?: ApiError) => {
+        this._mu.unlock();
+        cb(err);
+      });
+    });
+  }
+
+  mkdirSync(p: string, mode: number): void {
+    if (this._mu.isLocked())
+      throw new Error('invalid sync call');
+    return this._fs.mkdirSync(p, mode);
+  }
+
+  readdir(p: string, cb: (err: ApiError, files?: string[]) => void): void {
+    this._mu.lock(() => {
+      this._fs.readdir(p, (err?: ApiError, files?: string[]) => {
+        this._mu.unlock();
+        cb(err, files);
+      });
+    });
+  }
+
+  readdirSync(p: string): string[] {
+    if (this._mu.isLocked())
+      throw new Error('invalid sync call');
+    return this._fs.readdirSync(p);
+  }
+
+  exists(p: string, cb: (exists: boolean) => void): void {
+    this._mu.lock(() => {
+      this._fs.exists(p, (exists: boolean) => {
+        this._mu.unlock();
+        cb(exists);
+      });
+    });
+  }
+
+  existsSync(p: string): boolean {
+    if (this._mu.isLocked())
+      throw new Error('invalid sync call');
+    return this._fs.existsSync(p);
+  }
+
+  realpath(p: string, cache: {[path: string]: string}, cb: (err: ApiError, resolvedPath?: string) => any): void {
+    this._mu.lock(() => {
+      this._fs.realpath(p, cache, (err?: ApiError, resolvedPath?: string) => {
+        this._mu.unlock();
+        cb(err, resolvedPath);
+      });
+    });
+  }
+
+  realpathSync(p: string, cache: {[path: string]: string}): string {
+    if (this._mu.isLocked())
+      throw new Error('invalid sync call');
+    return this._fs.realpathSync(p, cache);
+  }
+
+  truncate(p: string, len: number, cb: Function): void {
+    this._mu.lock(() => {
+      this._fs.truncate(p, len, (err?: ApiError) => {
+        this._mu.unlock();
+        cb(err);
+      });
+    });
+  }
+
+  truncateSync(p: string, len: number): void {
+    if (this._mu.isLocked())
+      throw new Error('invalid sync call');
+    return this._fs.truncateSync(p, len);
+  }
+
+  readFile(fname: string, encoding: string, flag: FileFlag, cb: (err: ApiError, data?: any) => void): void {
+    this._mu.lock(() => {
+      this._fs.readFile(fname, encoding, flag, (err?: ApiError, data?: any) => {
+        this._mu.unlock();
+        cb(err, data);
+      });
+    });
+  }
+
+  readFileSync(fname: string, encoding: string, flag: FileFlag): any {
+    if (this._mu.isLocked())
+      throw new Error('invalid sync call');
+    return this._fs.readFileSync(fname, encoding, flag);
+  }
+
+  writeFile(fname: string, data: any, encoding: string, flag: FileFlag, mode: number, cb: (err: ApiError) => void): void {
+    this._mu.lock(() => {
+      this._fs.writeFile(fname, data, encoding, flag, mode, (err?: ApiError) => {
+        this._mu.unlock();
+        cb(err);
+      });
+    });
+  }
+
+  writeFileSync(fname: string, data: any, encoding: string, flag: FileFlag, mode: number): void {
+    if (this._mu.isLocked())
+      throw new Error('invalid sync call');
+    return this._fs.writeFileSync(fname, data, encoding, flag, mode);
+  }
+
+  appendFile(fname: string, data: any, encoding: string, flag: FileFlag, mode: number, cb: (err: ApiError) => void): void {
+    this._mu.lock(() => {
+      this._fs.appendFile(fname, data, encoding, flag, mode, (err?: ApiError) => {
+        this._mu.unlock();
+        cb(err);
+      });
+    });
+  }
+
+  appendFileSync(fname: string, data: any, encoding: string, flag: FileFlag, mode: number): void {
+    if (this._mu.isLocked())
+      throw new Error('invalid sync call');
+    return this._fs.appendFileSync(fname, data, encoding, flag, mode);
+  }
+
+  chmod(p: string, isLchmod: boolean, mode: number, cb: Function): void {
+    this._mu.lock(() => {
+      this._fs.chmod(p, isLchmod, mode, (err?: ApiError) => {
+        this._mu.unlock();
+        cb(err);
+      });
+    });
+  }
+
+  chmodSync(p: string, isLchmod: boolean, mode: number): void {
+    if (this._mu.isLocked())
+      throw new Error('invalid sync call');
+    return this._fs.chmodSync(p, isLchmod, mode);
+  }
+
+  chown(p: string, isLchown: boolean, uid: number, gid: number, cb: Function): void {
+    this._mu.lock(() => {
+      this._fs.chown(p, isLchown, uid, gid, (err?: ApiError) => {
+        this._mu.unlock();
+        cb(err);
+      });
+    });
+  }
+
+  chownSync(p: string, isLchown: boolean, uid: number, gid: number): void {
+    if (this._mu.isLocked())
+      throw new Error('invalid sync call');
+    return this._fs.chownSync(p, isLchown, uid, gid);
+  }
+
+  utimes(p: string, atime: Date, mtime: Date, cb: Function): void {
+    this._mu.lock(() => {
+      this._fs.utimes(p, atime, mtime, (err?: ApiError) => {
+        this._mu.unlock();
+        cb(err);
+      });
+    });
+  }
+
+  utimesSync(p: string, atime: Date, mtime: Date): void {
+    if (this._mu.isLocked())
+      throw new Error('invalid sync call');
+    return this._fs.utimesSync(p, atime, mtime);
+  }
+
+  link(srcpath: string, dstpath: string, cb: Function): void {
+    this._mu.lock(() => {
+      this._fs.link(srcpath, dstpath, (err?: ApiError) => {
+        this._mu.unlock();
+        cb(err);
+      });
+    });
+  }
+
+  linkSync(srcpath: string, dstpath: string): void {
+    if (this._mu.isLocked())
+      throw new Error('invalid sync call');
+    return this._fs.linkSync(srcpath, dstpath);
+  }
+
+  symlink(srcpath: string, dstpath: string, type: string, cb: Function): void {
+    this._mu.lock(() => {
+      this._fs.symlink(srcpath, dstpath, type, (err?: ApiError) => {
+        this._mu.unlock();
+        cb(err);
+      });
+    });
+  }
+
+  symlinkSync(srcpath: string, dstpath: string, type: string): void {
+    if (this._mu.isLocked())
+      throw new Error('invalid sync call');
+    return this._fs.symlinkSync(srcpath, dstpath, type);
+  }
+
+  readlink(p: string, cb: Function): void {
+    this._mu.lock(() => {
+      this._fs.readlink(p, (err?: ApiError, linkString?: string) => {
+        this._mu.unlock();
+        cb(err, linkString);
+      });
+    });
+  }
+
+  readlinkSync(p: string): string {
+    if (this._mu.isLocked())
+      throw new Error('invalid sync call');
+    return this._fs.readlinkSync(p);
+  }
+}

--- a/src/generic/locked_fs.ts
+++ b/src/generic/locked_fs.ts
@@ -72,8 +72,8 @@ export class LockedFS<T extends FileSystem> implements FileSystem {
   private _fs: T;
   private _mu: Mutex;
 
-  constructor(cls: {new(...args: any[]): T}, ...args: any[]) {
-    this._fs = new (Function.prototype.bind.apply(cls, [null].concat(args)));
+  constructor(fs: T) {
+    this._fs = fs;
     this._mu = new Mutex();
   }
 

--- a/src/generic/locked_fs.ts
+++ b/src/generic/locked_fs.ts
@@ -5,61 +5,6 @@ import {FileFlag, ActionType} from '../core/file_flag';
 import {default as Stats, FileType} from '../core/node_fs_stats';
 import {File} from '../core/file';
 
-// TODO: also implement LockedFile to ensure that operations on files
-// also grab the appropriate locks?.
-/*
-export LockedFile<T extends File> implements File {
-  private _file: File;
-  private _mu: Mutex;
-
-  constructor(mu: Mutex, f: File) {
-    this._file = f;
-    this._mu = mu;
-  }
-
-  getPos(): number;
-
-  stat(cb: (err: ApiError, stats?: Stats) => any): void;
-
-  statSync(): Stats;
-
-  close(cb: Function): void;
-
-  closeSync(): void;
-
-  truncate(len: number, cb: Function): void;
-
-  truncateSync(len: number): void;
-
-  sync(cb: (e?: ApiError) => void): void;
-
-  syncSync(): void;
-
-  write(buffer: NodeBuffer, offset: number, length: number, position: number, cb: (err: ApiError, written?: number, buffer?: NodeBuffer) => any): void;
-
-  writeSync(buffer: NodeBuffer, offset: number, length: number, position: number): number;
-
-  read(buffer: NodeBuffer, offset: number, length: number, position: number, cb: (err: ApiError, bytesRead?: number, buffer?: NodeBuffer) => void): void;
-
-  readSync(buffer: NodeBuffer, offset: number, length: number, position: number): number;
-
-  datasync(cb: (e?: ApiError) => void): void;
-
-  datasyncSync(): void;
-
-  chown(uid: number, gid: number, cb: (e?: ApiError) => void): void;
-
-  chownSync(uid: number, gid: number): void;
-
-  chmod(mode: number, cb: (e?: ApiError) => void): void;
-
-  chmodSync(mode: number): void;
-
-  utimes(atime: Date, mtime: Date, cb: (e?: ApiError) => void): void;
-
-  utimesSync(atime: Date, mtime: Date): void;
-}
-*/
 
 /// This class serializes access to an underlying async filesystem.
 /// For example, on an OverlayFS instance with an async lower

--- a/src/generic/locked_fs.ts
+++ b/src/generic/locked_fs.ts
@@ -1,4 +1,4 @@
-import {Mutex} from './mutex';
+import Mutex from './mutex';
 import {FileSystem, SynchronousFileSystem} from '../core/file_system';
 import {ApiError, ErrorCode} from '../core/api_error';
 import {FileFlag, ActionType} from '../core/file_flag';
@@ -6,7 +6,7 @@ import {default as Stats, FileType} from '../core/node_fs_stats';
 import {File} from '../core/file';
 
 // TODO: also implement LockedFile to ensure that operations on files
-// also grab the appropriate locks.
+// also grab the appropriate locks?.
 /*
 export LockedFile<T extends File> implements File {
   private _file: File;

--- a/src/generic/locked_fs.ts
+++ b/src/generic/locked_fs.ts
@@ -62,6 +62,12 @@ export LockedFile<T extends File> implements File {
 */
 
 /// This class serializes access to an underlying async filesystem.
+/// For example, on an OverlayFS instance with an async lower
+/// directory operations like rename and rmdir may involve multiple
+/// requests involving both the upper and lower filesystems -- they
+/// are not executed in a single atomic step.  OverlayFS uses this
+/// LockedFS to avoid having to reason about the correctness of
+/// multiple requests interleaving.
 export class LockedFS<T extends FileSystem> implements FileSystem {
   private _fs: T;
   private _mu: Mutex;

--- a/src/generic/locked_fs.ts
+++ b/src/generic/locked_fs.ts
@@ -68,7 +68,7 @@ export LockedFile<T extends File> implements File {
 /// are not executed in a single atomic step.  OverlayFS uses this
 /// LockedFS to avoid having to reason about the correctness of
 /// multiple requests interleaving.
-export class LockedFS<T extends FileSystem> implements FileSystem {
+export default class LockedFS<T extends FileSystem> implements FileSystem {
   private _fs: T;
   private _mu: Mutex;
 

--- a/src/generic/mutex.ts
+++ b/src/generic/mutex.ts
@@ -2,7 +2,7 @@
 declare var setImmediate: (cb: Function) => void;
 
 /// non-recursive mutex
-export class Mutex {
+export default class Mutex {
   private _locked: boolean = false;
   private _waiters: Function[] = [];
 

--- a/src/generic/mutex.ts
+++ b/src/generic/mutex.ts
@@ -1,0 +1,48 @@
+
+declare var setImmediate: (cb: Function) => void;
+
+/// non-recursive mutex
+export class Mutex {
+  private _locked: boolean = false;
+  private _waiters: Function[] = [];
+
+  lock(cb: Function): void {
+    if (this._locked) {
+      this._waiters.push(cb);
+      return;
+    }
+    this._locked = true;
+    cb();
+  }
+
+  unlock(): void {
+    if (!this._locked)
+      throw new Error('unlock of a non-locked mutex');
+
+    let next = this._waiters.shift();
+    // don't unlock - we want to queue up next for the
+    // _end_ of the current task execution, but we don't
+    // want it to be called inline with whatever the
+    // current stack is.  This way we still get the nice
+    // behavior that an unlock immediately followed by a
+    // lock won't cause starvation.
+    if (next) {
+      setImmediate(next);
+      return;
+    }
+
+    this._locked = false;
+  }
+
+  tryLock(): boolean {
+    if (this._locked)
+      return false;
+
+    this._locked = true;
+    return true;
+  }
+
+  isLocked(): boolean {
+    return this._locked;
+  }
+}

--- a/src/generic/xhr.ts
+++ b/src/generic/xhr.ts
@@ -220,7 +220,7 @@ function getFileSize(async: boolean, p: string, cb: (err: ApiError, size?: numbe
     if (req.readyState === 4) {
       if (req.status == 200) {
         try {
-          return cb(null, parseInt(req.getResponseHeader('Content-Length'), 10));
+          return cb(null, parseInt(req.getResponseHeader('Content-Length') || '-1', 10));
         } catch(e) {
           // In the event that the header isn't present or there is an error...
           return cb(new ApiError(ErrorCode.EIO, "XHR HEAD error: Could not read content-length."));

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -42,6 +42,8 @@
         "src/generic/key_value_filesystem.ts",
         "src/generic/preload_file.ts",
         "src/generic/xhr.ts",
+        "src/generic/mutex.ts",
+        "src/generic/locked_fs.ts",
         "test/harness/BackendFactory.ts",
         "test/harness/run.ts",
         "test/harness/common.ts",


### PR DESCRIPTION
hi @jvilk,

Consider this a proposal for async support in OverlayFS.  A couple of
big things here:

- with the lower directory being async, operations (like rename,
  rmdir, and others) may ping-pong back and forth between requests to
  the upper layer and lower layer, to check if files exist or
  copy/delete directory contents.  I'm interested in stacking multiple
  overlays on top of each other, which will only exacerbate the
  situation.  To deal with this, I've added Java-style locking to the
  exposed OverlayFS object -- only one request can proceed at a time,
  to avoid thinking about correctness when you interleave two fs
  requests together.  I need to go back and see if there is more
  locking that should happen around the File object.
- async versions of all the methods on OverlayFS.
- a few small fixes, such as using the buffer size if a Content-Length
  header isn't returned on an XMLHttpRequest (such as for chunked
  responses?)

I'm still doing more testing with browsix - so I'd like to hold off
until I extend some of browsix's tests to make sure nothing is hinkey,
but so far it is looking good!