### PR TITLE
backend/OverlayFS.openSync: avoid stat() before unconditional readFile()

### DIFF
--- a/src/backend/OverlayFS.ts
+++ b/src/backend/OverlayFS.ts
@@ -567,9 +567,10 @@ export class UnlockedOverlayFS extends BaseFileSystem implements FileSystem {
             return this._writable.openSync(p, flag, mode);
           } else {
             // Create an OverlayFile.
+            var buf = this._readable.readFileSync(p, null, getFlag('r'));
             var stats = this._readable.statSync(p, false).clone();
             stats.mode = mode;
-            return new OverlayFile(this, p, flag, stats, this._readable.readFileSync(p, null, getFlag('r')));
+            return new OverlayFile(this, p, flag, stats, buf);
           }
         default:
           throw ApiError.EEXIST(p);


### PR DESCRIPTION
This avoids an HTTP roundtrip when the underlying FS is an
XmlHttpRequestFS.  Previously, the stat() would issue a HEAD (for the
`stat()`) immediately followed by an unconditional GET of the full
resource.  In at least Chrome, performing a HEAD request is not cached
by itself, and often invalidates cached (GET) resources:

https://bugs.chromium.org/p/chromium/issues/detail?id=350407