### PR TITLE
"prepublish" script ignored in favor of "prepare" script in future npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "test": "npm-run-all test:prepare test:karma",
     "watch-test": "npm-run-all test:prepare --parallel watch:scripts test:watch test:karma",
     "prepublish": "npm run dist",
+    "prepare": "npm run dist",
     "docs": "typedoc --mode modules --out doc --excludePrivate --readme src/DOCS.md --name BrowserFS --module umd src"
   },
   "dependencies": {


### PR DESCRIPTION
> $ npm install
npm WARN prepublish-on-install As of npm@5, `prepublish` scripts are deprecated.
npm WARN prepublish-on-install Use `prepare` for build steps and `prepublishOnly` for upload-only.
npm WARN prepublish-on-install See the deprecation note in `npm help scripts` for more information.

Probably my smallest PR ever.