### PR TITLE
Let BrowserFS.configure() return a Promise instead of requiring a callback

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: precise
 language: node_js
 node_js:
   - "4"

--- a/src/core/FS.ts
+++ b/src/core/FS.ts
@@ -419,7 +419,7 @@ export default class FS {
   public readFile(filename: string, options: { flag?: string; }, callback?: BFSCallback<Buffer>): void;
   public readFile(filename: string, options: { encoding: string; flag?: string; }, callback?: BFSCallback<string>): void;
   public readFile(filename: string, encoding: string, cb: BFSCallback<string>): void;
-  public readFile(filename: string, arg2: any = {}, cb: BFSCallback<any> = nopCb ) {
+  public readFile(filename: string, arg2: any = {}, cb: BFSCallback<any> = nopCb) {
     const options = normalizeOptions(arg2, null, 'r', null);
     cb = typeof arg2 === 'function' ? arg2 : cb;
     const newCb = wrapCb(cb, 2);

--- a/src/core/browserfs.ts
+++ b/src/core/browserfs.ts
@@ -81,14 +81,20 @@ export function initialize(rootfs: FileSystem) {
  * Creates a file system with the given configuration, and initializes BrowserFS with it.
  * See the FileSystemConfiguration type for more info on the configuration object.
  */
-export function configure(config: FileSystemConfiguration, cb: BFSOneArgCallback): void {
-  getFileSystem(config, (e, fs?) => {
-    if (fs) {
+export function configure(config: FileSystemConfiguration, cb: BFSOneArgCallback): void;
+export function configure(config: FileSystemConfiguration): Promise<FileSystem>;
+export function configure(config: FileSystemConfiguration, cb?: BFSOneArgCallback): any {
+  if (cb) {
+    return configure(config).then(() => cb()).catch(cb);
+  }
+  return new Promise(function(resolve, reject) {
+    getFileSystem(config, (e, fs?) => {
+      if (e || fs === undefined) {
+        return reject(e);
+      }
       initialize(fs);
-      cb();
-    } else {
-      cb(e);
-    }
+      resolve(fs);
+    });
   });
 }
 


### PR DESCRIPTION
Currently, `BrowserFS.configure()` is a little awkward if you are not using `BrowserFS.install(window)`. You end up with something like:

```js
BrowserFS.configure({
  fs: "LocalStorage"
}, (e) => {
  if (e) throw e;
  const fs = BrowserFS.BFSRequire('fs');
  /*DO STUFF WITH FS*/
});
```

Then it gets more awkward if you have multiple modules acting on the file system, because I don't think you want to call `BrowserFS.configure` once in each module. So what I've been doing in my project is wrapping the file system as a const Promise like this:

```js
// filesystem.js
export const Files = new Promise(function(resolve, reject) {
  BrowserFS.configure({
    fs: "LocalStorage"
  }, (err) => err ? reject(err) : resolve(BrowserFS.BFSRequire('fs')))
})
```

so I can use it like this:
```js
// app.js
import Files from './filesystem'
Files.then(fs => /*DO STUFF WITH FS*/)
```

This PR would make the callback to `BrowserFS.configure` optional. If it detects there's no callback, instead of returning `void` it returns a `Promise<FileSystem>`. This simplifies the weird boilerplate in my example 'filesystem.js' above so it looks like this:

```js
// filesystem.js (PR edition)
export const Files = BrowserFS.configure({
  fs: "LocalStorage"
})
```

If you like the idea I can try to add a test case and update the documentation.