### PR TITLE
CacheStorage backend

### DIFF
--- a/src/backend/CacheStorage.ts
+++ b/src/backend/CacheStorage.ts
@@ -29,13 +29,13 @@ export class CacheStorageROTransaction implements AsyncKeyValueROTransaction {
 
   public get(key: string, cb: BFSCallback<Buffer>): void {
     this.store.match(key)
-    .then((res : any) => {
+    .then((res: any) => {
       if (res === undefined) {
         setTimeout(() => cb(null, res), 0);
       } else {
         res.arrayBuffer()
-        .then((buffer : ArrayBuffer) => cb(null, arrayBuffer2Buffer(buffer)))
-        .catch((err : any) => cb(convertError(err)));
+        .then((buffer: ArrayBuffer) => cb(null, arrayBuffer2Buffer(buffer)))
+        .catch((err: any) => cb(convertError(err)));
       }
     })
     .catch((err) => cb(convertError(err)));
@@ -173,7 +173,14 @@ export default class CacheStorageFileSystem extends AsyncKeyValueFileSystem {
   public static Create(opts: CacheStorageFileSystemOptions, cb: BFSCallback<CacheStorageFileSystem>): void {
     CacheStore.Create(opts.storeName ? opts.storeName : 'browserfs', (e, store?) => {
       if (store) {
-        cb(null, new CacheStorageFileSystem(store));
+        const csfs = new CacheStorageFileSystem();
+        csfs.init(store, (e) => {
+          if (e) {
+            cb(e);
+          } else {
+            cb(null, csfs);
+          }
+        });
       } else {
         cb(e);
       }
@@ -182,9 +189,8 @@ export default class CacheStorageFileSystem extends AsyncKeyValueFileSystem {
   public static isAvailable(): boolean {
     return global.caches !== undefined;
   }
-  private constructor(store: CacheStore) {
+  private constructor() {
     super();
-    this.store = store;
   }
 
   public supportsSynch(): boolean {

--- a/src/backend/CacheStorage.ts
+++ b/src/backend/CacheStorage.ts
@@ -1,0 +1,203 @@
+import {BFSOneArgCallback, BFSCallback, FileSystemOptions} from '../core/file_system';
+import {AsyncKeyValueROTransaction, AsyncKeyValueRWTransaction, AsyncKeyValueStore, AsyncKeyValueFileSystem} from '../generic/key_value_filesystem';
+import {ApiError, ErrorCode} from '../core/api_error';
+import global from '../core/global';
+import {arrayBuffer2Buffer, buffer2ArrayBuffer} from '../core/util';
+
+/**
+ * Converts a DOMException or a DOMError from an Cache event into a
+ * standardized BrowserFS API error.
+ * @hidden
+ */
+function convertError(e: {name: string}, message: string = e.toString()): ApiError {
+  switch (e.name) {
+    case "NotFoundError":
+      return new ApiError(ErrorCode.ENOENT, message);
+    case "QuotaExceededError":
+      return new ApiError(ErrorCode.ENOSPC, message);
+    default:
+      // The rest do not seem to map cleanly to standard error codes.
+      return new ApiError(ErrorCode.EIO, message);
+  }
+}
+
+/**
+ * @hidden
+ */
+export class CacheStorageROTransaction implements AsyncKeyValueROTransaction {
+  constructor(public store: Cache) { }
+
+  public get(key: string, cb: BFSCallback<Buffer>): void {
+    this.store.match(key)
+    .then((res : any) => {
+      if (res === undefined) {
+        setTimeout(() => cb(null, res), 0);
+      } else {
+        res.arrayBuffer()
+        .then((buffer : ArrayBuffer) => cb(null, arrayBuffer2Buffer(buffer)))
+        .catch((err : any) => cb(convertError(err)));
+      }
+    })
+    .catch((err) => cb(convertError(err)));
+  }
+}
+
+/**
+ * @hidden
+ */
+export class CacheStorageRWTransaction extends CacheStorageROTransaction implements AsyncKeyValueRWTransaction, AsyncKeyValueROTransaction {
+  constructor(store: Cache) {
+    super(store);
+  }
+
+  public put(key: string, data: Buffer, overwrite: boolean, cb: BFSCallback<boolean>): void {
+    try {
+      const arraybuffer = buffer2ArrayBuffer(data);
+      if (overwrite) {
+        this.store.put(key, new Response(arraybuffer))
+        .then(() => cb(null, true))
+        .catch((err) => cb(convertError(err)));
+      } else {
+        this.store.match(key)
+        .then((match) => {
+          if (match === undefined) {
+            this.store.put(key, new Response(arraybuffer))
+            .then(() => cb(null, true))
+            .catch((err) => cb(convertError(err)));
+          } else {
+            cb(null, false);
+          }
+        })
+        .catch((err) => {
+          cb(convertError(err));
+        });
+      }
+    } catch (e) {
+      cb(convertError(e));
+    }
+  }
+
+  public del(key: string, cb: BFSOneArgCallback): void {
+    this.store.delete(key)
+    .then(() => cb())
+    .catch((err) => cb(convertError(err)));
+  }
+
+  public commit(cb: BFSOneArgCallback): void {
+    // Return to the event loop to commit the transaction.
+    setTimeout(cb, 0);
+  }
+
+  public abort(cb: BFSOneArgCallback): void {
+    if (cb) {
+      setTimeout(cb, 0);
+    }
+  }
+}
+
+export class CacheStore implements AsyncKeyValueStore {
+  public static Create(storeName: string, cb: BFSCallback<CacheStore>): void {
+    caches.open(storeName)
+    .then((cache) => {
+      cb(null, new CacheStore(cache, storeName));
+    })
+    .catch((err) => {
+      cb(new ApiError(ErrorCode.EACCES));
+    });
+  }
+
+  constructor(private cache: Cache, private storeName: string) {
+
+  }
+
+  public name(): string {
+    return CacheStorageFileSystem.Name + " - " + this.storeName;
+  }
+
+  public clear(cb: BFSOneArgCallback): void {
+    caches.delete(this.storeName)
+    .then(() => {
+      caches.open(this.storeName)
+      .then((cache) => {
+        this.cache = cache;
+        cb();
+      })
+      .catch((err) => {
+        cb(convertError(err));
+      });
+    })
+    .catch((err) => {
+      cb(convertError(err));
+    });
+  }
+
+  public beginTransaction(type: 'readonly'): AsyncKeyValueROTransaction;
+  public beginTransaction(type: 'readwrite'): AsyncKeyValueRWTransaction;
+  public beginTransaction(type: 'readonly' | 'readwrite' = 'readonly'): AsyncKeyValueROTransaction {
+    if (type === 'readwrite') {
+      return new CacheStorageRWTransaction(this.cache);
+    } else if (type === 'readonly') {
+      return new CacheStorageROTransaction(this.cache);
+    } else {
+      throw new ApiError(ErrorCode.EINVAL, 'Invalid transaction type.');
+    }
+  }
+}
+
+/**
+ * Configuration options for the CacheStorage file system.
+ */
+export interface CacheStorageFileSystemOptions {
+  // The name of this file system. You can have multiple CacheStorage file systems operating
+  // at once, but each must have a different name.
+  storeName?: string;
+}
+
+/**
+ * A file system that uses the Cache Storage API.
+ */
+export default class CacheStorageFileSystem extends AsyncKeyValueFileSystem {
+  public static readonly Name = "CacheStorage";
+
+  public static readonly Options: FileSystemOptions = {
+    storeName: {
+      type: "string",
+      optional: true,
+      description: "The name of this file system. You can have multiple CacheStorageFS file systems operating at once, but each must have a different name."
+    }
+  };
+
+  /**
+   * Constructs an CacheStorage file system with the given options.
+   */
+  public static Create(opts: CacheStorageFileSystemOptions, cb: BFSCallback<CacheStorageFileSystem>): void {
+    CacheStore.Create(opts.storeName ? opts.storeName : 'browserfs', (e, store?) => {
+      if (store) {
+        cb(null, new CacheStorageFileSystem(store));
+      } else {
+        cb(e);
+      }
+    });
+  }
+  public static isAvailable(): boolean {
+    return global.caches !== undefined;
+  }
+  private constructor(store: CacheStore) {
+    super();
+    this.store = store;
+  }
+
+  public supportsSynch(): boolean {
+    // The Cache API doesn't have any support for synchronous operations. It's all Promise based.
+    return false;
+  }
+
+  // public supportsLinks(): boolean {
+  //   return false;
+  // }
+
+  // public supportsProps(): boolean {
+  //   return false;
+  // }
+
+}

--- a/src/core/backends.ts
+++ b/src/core/backends.ts
@@ -2,6 +2,7 @@ import {FileSystemConstructor, BFSCallback, FileSystem} from './file_system';
 import {ApiError} from './api_error';
 import {checkOptions} from './util';
 import AsyncMirror from '../backend/AsyncMirror';
+import CacheStorage from '../backend/CacheStorage';
 import Dropbox from '../backend/Dropbox';
 import Emscripten from '../backend/Emscripten';
 import FolderAdapter from '../backend/FolderAdapter';
@@ -17,7 +18,7 @@ import ZipFS from '../backend/ZipFS';
 import IsoFS from '../backend/IsoFS';
 
 // Monkey-patch `Create` functions to check options before file system initialization.
-[AsyncMirror, Dropbox, Emscripten, FolderAdapter, HTML5FS, InMemory, IndexedDB, IsoFS, LocalStorage, MountableFileSystem, OverlayFS, WorkerFS, HTTPRequest, ZipFS].forEach((fsType: FileSystemConstructor) => {
+[AsyncMirror, CacheStorage, Dropbox, Emscripten, FolderAdapter, HTML5FS, InMemory, IndexedDB, IsoFS, CacheStorage, MountableFileSystem, OverlayFS, WorkerFS, HTTPRequest, ZipFS].forEach((fsType: FileSystemConstructor) => {
   const create = fsType.Create;
   fsType.Create = function(opts?: any, cb?: BFSCallback<FileSystem>): void {
     const oneArg = typeof(opts) === "function";
@@ -39,7 +40,7 @@ import IsoFS from '../backend/IsoFS';
 /**
  * @hidden
  */
-const Backends = { AsyncMirror, Dropbox, Emscripten, FolderAdapter, HTML5FS, InMemory, IndexedDB, IsoFS, LocalStorage, MountableFileSystem, OverlayFS, WorkerFS, HTTPRequest, XmlHttpRequest: HTTPRequest, ZipFS };
+const Backends = { AsyncMirror, CacheStorage, Dropbox, Emscripten, FolderAdapter, HTML5FS, InMemory, IndexedDB, IsoFS, LocalStorage, MountableFileSystem, OverlayFS, WorkerFS, HTTPRequest, XmlHttpRequest: HTTPRequest, ZipFS };
 // Make sure all backends cast to FileSystemConstructor (for type checking)
 const _: {[name: string]: FileSystemConstructor} = Backends;
 // tslint:disable-next-line:no-unused-expression

--- a/test/harness/factories/cache_storage_factory.ts
+++ b/test/harness/factories/cache_storage_factory.ts
@@ -1,0 +1,22 @@
+import CacheStorageFileSystem from '../../../src/backend/CacheStorage';
+import {FileSystem} from '../../../src/core/file_system';
+
+export default function CacheStorageFSFactory(cb: (name: string, obj: FileSystem[]) => void): void {
+  if (CacheStorageFileSystem.isAvailable()) {
+    CacheStorageFileSystem.Create({
+      storeName: `test-${Math.random()}`
+    }, (e, fs?) => {
+      if (e) {
+        throw e;
+      }
+      fs.empty((e?) => {
+        if (e) {
+          throw e;
+        }
+        cb('CacheStorageFS', [fs]);
+      });
+    });
+  } else {
+    cb('CacheStorageFS', []);
+  }
+}

--- a/test/harness/factories/cache_storage_factory.ts
+++ b/test/harness/factories/cache_storage_factory.ts
@@ -1,7 +1,7 @@
 import CacheStorageFileSystem from '../../../src/backend/CacheStorage';
 import {FileSystem} from '../../../src/core/file_system';
 
-export default function CacheStorageFSFactory(cb: (name: string, obj: FileSystem[]) => void): void {
+export default function CacheStorageFactory(cb: (name: string, obj: FileSystem[]) => void): void {
   if (CacheStorageFileSystem.isAvailable()) {
     CacheStorageFileSystem.Create({
       storeName: `test-${Math.random()}`
@@ -13,10 +13,10 @@ export default function CacheStorageFSFactory(cb: (name: string, obj: FileSystem
         if (e) {
           throw e;
         }
-        cb('CacheStorageFS', [fs]);
+        cb('CacheStorage', [fs]);
       });
     });
   } else {
-    cb('CacheStorageFS', []);
+    cb('CacheStorage', []);
   }
 }


### PR DESCRIPTION
This adds a new backend based on the Cache Storage API, which is like the Indexed DB API in that it is an async only API accessible to both window code and worker code. But it is a much more natural fit for a binary key value store than IDB with its sorted indexes and painful event model ever was, so I am anticipating (perhaps incorrectly) that this backend will have much faster write speeds than the IDB backend.

Tests are failing almost immediately. I don't know why - I was able to do mkdir, readdir, writeFile, readFile using the "dist" build in Chrome. I'm going to try using the dist build with isomorphic-git and see if that underlying anything.