### PR TITLE
Options

### DIFF
--- a/src/core/FS.ts
+++ b/src/core/FS.ts
@@ -79,6 +79,13 @@ function normalizePath(p: string): string {
 function normalizeOptions(options: any, defEnc: string | null, defFlag: string, defMode: number | null): {encoding: string; flag: string; mode: number} {
   switch (typeof options) {
     case 'object':
+      if (options === null) {
+        return {
+          encoding: defEnc!,
+          flag: defFlag,
+          mode: defMode!
+        };
+      }
       return {
         encoding: typeof options['encoding'] !== 'undefined' ? options['encoding'] : defEnc,
         flag: typeof options['flag'] !== 'undefined' ? options['flag'] : defFlag,

--- a/src/core/FS.ts
+++ b/src/core/FS.ts
@@ -7,6 +7,7 @@ import Stats from './node_fs_stats';
 
 // Typing info only.
 import * as _fs from 'fs';
+import {encodeStrings} from "./util";
 
 /**
  * Wraps a callback function. Used for unit testing. Defaults to a NOP.
@@ -1068,13 +1069,22 @@ export default class FS {
    * The callback gets two arguments `(err, files)` where `files` is an array of
    * the names of the files in the directory excluding `'.'` and `'..'`.
    * @param path
+   * @param options
    * @param callback
    */
-  public readdir(path: string, cb: BFSCallback<string[]> = nopCb): void {
-    const newCb = <(err: ApiError, files?: string[]) => void> wrapCb(cb, 2);
+  public readdir(path: string, cb: BFSCallback<string[] | Buffer[]>): void;
+  public readdir(path: string, options: { encoding: string }, cb: BFSCallback<string[] | Buffer[]>): void;
+  public readdir(path: string, encoding: string, cb: BFSCallback<string[] | Buffer[]>): void;
+  public readdir(path: string, arg2: any = {}, cb: BFSCallback<string[] | Buffer[]> = nopCb): void {
+    const options = normalizeOptions(arg2, 'utf8', 'r', null);
+    cb = typeof arg2 === 'function' ? arg2 : cb;
+    const newCb = <(err: ApiError, files?: string[] | Buffer[]) => void> wrapCb(cb, 2);
     try {
       path = normalizePath(path);
-      assertRoot(this.root).readdir(path, newCb);
+      assertRoot(this.root).readdir(path, (err: ApiError, files?: string[]) => {
+        const encodedFiles = files && encodeStrings(files, options.encoding);
+        newCb(err, encodedFiles);
+      });
     } catch (e) {
       newCb(e);
     }
@@ -1083,11 +1093,15 @@ export default class FS {
   /**
    * Synchronous `readdir`. Reads the contents of a directory.
    * @param path
+   * @param options
    * @return [String[]]
    */
-  public readdirSync(path: string): string[] {
+  public readdirSync(path: string, options?: { encoding: string }): string[] | Buffer[];
+  public readdirSync(path: string, encoding: string): string[] | Buffer[];
+  public readdirSync(path: string, arg2: any = {}): string[] | Buffer[] {
+    const options = normalizeOptions(arg2, 'utf8', 'r', null);
     path = normalizePath(path);
-    return assertRoot(this.root).readdirSync(path);
+    return encodeStrings(assertRoot(this.root).readdirSync(path), options.encoding);
   }
 
   // SYMLINK METHODS

--- a/src/core/util.ts
+++ b/src/core/util.ts
@@ -254,3 +254,14 @@ export function checkOptions(fsType: FileSystemConstructor, opts: any, cb: BFSOn
     cb();
   }
 }
+
+export function encodeStrings(strings: string[], encoding: string): string[] | Buffer[] {
+  switch (encoding) {
+    case 'utf8':
+      return strings;
+    case 'buffer':
+      return strings.map((filename) => Buffer.from(filename));
+    default:
+      return strings.map((filename) => Buffer.from(filename).toString(encoding));
+  }
+}

--- a/src/generic/emscripten_fs.ts
+++ b/src/generic/emscripten_fs.ts
@@ -307,7 +307,7 @@ class BFSEmscriptenNodeOps implements EmscriptenNodeOps {
     try {
       // Node does not list . and .. in directory listings,
       // but Emscripten expects it.
-      const contents = this.nodefs.readdirSync(path);
+      const contents = <string[]> this.nodefs.readdirSync(path);
       contents.push('.', '..');
       return contents;
     } catch (e) {

--- a/test/tests/fs/HTTPRequest/listing.ts
+++ b/test/tests/fs/HTTPRequest/listing.ts
@@ -34,10 +34,10 @@ export default function() {
 
     let t1text = 'Invariant fail: Can query folder that contains items and a mount point.';
     let expectedTestListing = ['README.md', 'src', 'test'];
-    let testListing = fs.readdirSync('/').sort();
+    let testListing = (<string[]> fs.readdirSync('/')).sort();
     assert.deepEqual(testListing, expectedTestListing, t1text);
 
-    fs.readdir('/', function(err, files) {
+    fs.readdir('/', function(err, files: string[]) {
       assert(!err, t1text);
       assert.deepEqual(files.sort(), expectedTestListing, t1text);
       fs.stat("/test/fixtures/static/49chars.txt", function(err, stats) {

--- a/test/tests/fs/IsoFS/nested-directories.ts
+++ b/test/tests/fs/IsoFS/nested-directories.ts
@@ -6,7 +6,7 @@ export default function() {
   let p = root;
   let dirs = fs.readdirSync(p);
   for (let i = 1; i < 9; i++) {
-    assert(dirs.indexOf(i.toString()) !== -1, `ISO is missing directory ${i}`);
+    assert((<string[]> dirs).indexOf(i.toString()) !== -1, `ISO is missing directory ${i}`);
     p = `${p}/${i}`;
     dirs = fs.readdirSync(p);
   }

--- a/test/tests/fs/MountableFileSystem/mounting.ts
+++ b/test/tests/fs/MountableFileSystem/mounting.ts
@@ -43,10 +43,10 @@ export default function() {
 
       var t1text = 'Invariant fail: Can query folder that contains items and a mount point.';
       var expectedHomeListing = ['anotherFolder', 'secondRoot'];
-      var homeListing = fs.readdirSync('/root/home').sort();
+      var homeListing = (<string[]> fs.readdirSync('/root/home')).sort();
       assert.deepEqual(homeListing, expectedHomeListing, t1text);
 
-      fs.readdir('/root/home', function(err, files) {
+      fs.readdir('/root/home', function(err, files: string[]) {
         assert(!err, t1text);
         assert.deepEqual(files.sort(), expectedHomeListing, t1text);
 
@@ -77,7 +77,7 @@ export default function() {
             fs.rmdir('/root/home', function(err) {
               assert(err, t5text);
 
-              assert.deepEqual(fs.readdirSync('/root').sort(), ['anotherRoot', 'home'], "Invariant fail: Directory listings do not contain duplicate items when folder contains mount points w/ same names as existing files/folders.");
+              assert.deepEqual((<string[]> fs.readdirSync('/root')).sort(), ['anotherRoot', 'home'], "Invariant fail: Directory listings do not contain duplicate items when folder contains mount points w/ same names as existing files/folders.");
 
               BrowserFS.FileSystem.InMemory.Create({}, (e, newRoot?) => {
                 if (!newRoot) {

--- a/test/tests/fs/OverlayFS/persist-test.ts
+++ b/test/tests/fs/OverlayFS/persist-test.ts
@@ -18,7 +18,7 @@ export default function() {
 
   // Ensure no files are doubled.
   var seenMap: string[] = [];
-  fs.readdirSync('/test/fixtures/files/node').forEach(function(file) {
+  (<string[]> fs.readdirSync('/test/fixtures/files/node')).forEach(function(file) {
     assert(seenMap.indexOf(file) === -1, "File " + file + " cannot exist multiple times.");
     seenMap.push(file);
     fs.unlinkSync('/test/fixtures/files/node/' + file);
@@ -27,7 +27,7 @@ export default function() {
   fs.rmdirSync('/test/fixtures/files/node');
 
   assert(fs.existsSync('/test/fixtures/files/node') === false, 'Directory must be deleted');
-  assert(fs.readdirSync('/test/fixtures/files').indexOf('node') === -1, 'Directory must be empty.');
+  assert((<string[]> fs.readdirSync('/test/fixtures/files')).indexOf('node') === -1, 'Directory must be empty.');
 
   OverlayFS.Create({readable, writable}, (e, newCombined) => {
     assert(newCombined.existsSync('/test/fixtures/files/node') === false, 'Directory must still be deleted.');
@@ -37,7 +37,7 @@ export default function() {
       OverlayFS.Create({ writable, readable}, (e, newFs) => {
         fs.initialize(newFs);
         assert(fs.existsSync('/test/fixtures/files/node') === true, "Directory must be back");
-        assert(fs.readdirSync('/test/fixtures/files').indexOf('node') > -1, "Directory must be back.");
+        assert((<string[]> fs.readdirSync('/test/fixtures/files')).indexOf('node') > -1, "Directory must be back.");
         // XXX: Remake the tmpdir.
         fs.mkdirSync(common.tmpDir);
       });


### PR DESCRIPTION
Hi!

I've added a couple of small changes for better compatibility with Node.js fs module:

1. Passing null as an options argument makes a file operation use the default options (currently, it causes a null dereference exception).
2. readdir and readdirSync support the options argument according to the Node.js API specification (currently, this argument is not supported and causes a failure if it is passed).

For simplicity, I made the second change in the FS object, whereas similar processing for readFile etc. is performed in particular file systems.

I would be glad to see these changes in the upstream version.
  