### PR TITLE
Add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
Normalize line endings to LF so the linter doesn't complain and tests pass on Windows.

It also required running some commands to update the local repo; these steps would be required for anyone who had previously cloned on Windows (or alternatively the repo could be deleted and recloned):
```sh
# (DANGEROUS & DELETEY)
git rm --cached -r .  # Remove every file from git's index.
git reset --hard      # Rewrite git's index to pick up all the new line endings.
```
