### PR TITLE
[WIP] Recover from missing root after IndexedDB cleared

### DIFF
--- a/src/backend/IndexedDB.ts
+++ b/src/backend/IndexedDB.ts
@@ -214,7 +214,14 @@ export default class IndexedDBFileSystem extends AsyncKeyValueFileSystem {
   public static Create(opts: IndexedDBFileSystemOptions, cb: BFSCallback<IndexedDBFileSystem>): void {
     IndexedDBStore.Create(opts.storeName ? opts.storeName : 'browserfs', (e, store?) => {
       if (store) {
-        cb(null, new IndexedDBFileSystem(store));
+        const idbfs = new IndexedDBFileSystem(store);
+        idbfs.init(idbfs.store, (e) => {
+          debugger;
+          if (e) {
+            return cb(e);
+          }
+          cb(null, idbfs);
+        });
       } else {
         cb(e);
       }

--- a/src/backend/OverlayFS.ts
+++ b/src/backend/OverlayFS.ts
@@ -854,9 +854,13 @@ export class UnlockedOverlayFS extends BaseFileSystem implements FileSystem {
     this._writable.stat(parent, false, statDone);
     function statDone(err: ApiError, stat?: Stats): void {
       if (err) {
-        toCreate.push(parent);
-        parent = path.dirname(parent);
-        self._writable.stat(parent, false, statDone);
+        if (parent === "/") {
+          cb(new ApiError(ErrorCode.EBUSY, "Invariant failed: root does not exist!"));
+        } else {
+          toCreate.push(parent);
+          parent = path.dirname(parent);
+          self._writable.stat(parent, false, statDone);
+        }
       } else {
         createParents();
       }


### PR DESCRIPTION
Only at init time; maybe it should be able to recover immediately!

I mean, "Fix missing root in IndexedDB after database cleared" is, well, maybe not *inaccurate*, but it doesn't happen immediately; it doesn't recover immediately. It takes a page refresh of an app, generally.

Also I took a stab at testing this, but haven't tested whether the test tests it yet:

```ts
  // Does the root directory exist in empty file systems? It should!
  BrowserFS.FileSystem.IndexedDB.Create({}, (e, idbfs) => {
    idbfs.stat('/', true, function (err) {
      if (err) throw err;
    });
  });
```