### PR TITLE
promise no setTimeout

### DIFF
--- a/src/backend/IndexedDB.ts
+++ b/src/backend/IndexedDB.ts
@@ -1,3 +1,4 @@
+import setImmediate from '../generic/setImmediate';
 import {BFSOneArgCallback, BFSCallback, FileSystemOptions} from '../core/file_system';
 import {AsyncKeyValueROTransaction, AsyncKeyValueRWTransaction, AsyncKeyValueStore, AsyncKeyValueFileSystem} from '../generic/key_value_filesystem';
 import {ApiError, ErrorCode} from '../core/api_error';
@@ -111,7 +112,7 @@ export class IndexedDBRWTransaction extends IndexedDBROTransaction implements As
 
   public commit(cb: BFSOneArgCallback): void {
     // Return to the event loop to commit the transaction.
-    setTimeout(cb, 0);
+    setImmediate(cb);
   }
 
   public abort(cb: BFSOneArgCallback): void {
@@ -161,8 +162,8 @@ export class IndexedDBStore implements AsyncKeyValueStore {
         objectStore = tx.objectStore(this.storeName),
         r: IDBRequest = objectStore.clear();
       r.onsuccess = (event) => {
-        // Use setTimeout to commit transaction.
-        setTimeout(cb, 0);
+        // Use setImmediate to commit transaction.
+        setImmediate(cb);
       };
       r.onerror = onErrorHandler(cb);
     } catch (e) {

--- a/src/generic/setImmediate.ts
+++ b/src/generic/setImmediate.ts
@@ -60,7 +60,7 @@ if (typeof(setImmediate) !== "undefined") {
     };
   } else {
     bfsSetImmediate = function(fn: () => void) {
-      return setTimeout(fn, 0);
+      return Promise.resolve().then(fn);
     };
   }
 }


### PR DESCRIPTION
This very simple change to setImmediate seems to speed things up even on the test suite. It is hard to be sure since I can't run the tests locally, but I believe there is sufficient evidence to believe this speed up is real, as per:

https://github.com/jvilk/BrowserFS/issues/237#issuecomment-390038803