### PR TITLE
Invoke callbacks asynchronously

### DIFF
--- a/test/harness/setup.ts
+++ b/test/harness/setup.ts
@@ -5,7 +5,6 @@ import {eachSeries as asyncEachSeries} from 'async';
 import BFSEmscriptenFS from '../../src/generic/emscripten_fs';
 import assert from './wrapped-assert';
 import loadFixtures from '../fixtures/load_fixtures';
-import setImmediate from '../../src/generic/setImmediate';
 
 declare var __numWaiting: number;
 declare var __karma__: any;
@@ -47,9 +46,6 @@ export default function(tests: {
   const fs = BrowserFS.BFSRequire('fs');
   const path = BrowserFS.BFSRequire('path');
   fs.wrapCallbacks((cb, numArgs) => {
-    if (typeof cb !== 'function') {
-      throw new Error('Callback must be a function.');
-    }
     // This is used for unit testing.
     // We could use `arguments`, but Function.call/apply is expensive. And we only
     // need to handle 1-3 arguments
@@ -61,24 +57,18 @@ export default function(tests: {
     switch (numArgs) {
       case 1:
         return <any> function(arg1: any) {
-          setImmediate(function() {
-            __numWaiting--;
-            return cb(arg1);
-          });
+          __numWaiting--;
+          return cb(arg1);
         };
       case 2:
         return <any> function(arg1: any, arg2: any) {
-          setImmediate(function() {
-            __numWaiting--;
-            return cb(arg1, arg2);
-          });
+          __numWaiting--;
+          return cb(arg1, arg2);
         };
       case 3:
         return <any> function(arg1: any, arg2: any, arg3: any) {
-          setImmediate(function() {
-            __numWaiting--;
-            return cb(arg1, arg2, arg3);
-          });
+          __numWaiting--;
+          return cb(arg1, arg2, arg3);
         };
       default:
         throw new Error('Invalid invocation of wrapCb.');


### PR DESCRIPTION
The BrowserFS `FileSystem` interface documents several assumptions about
arguments passed to API implementations. Notably, it is documented that
callbacks will reset the stack depth using `setImmediate`.
https://github.com/jvilk/BrowserFS/blob/28a26cbcb89b5cef59a586f55045aabe98561f47/src/core/file_system.ts#L57-L59

This assumption originally held true, but the implementation was removed
for release builds in #139. This change broke code that relied upon
callbacks being asynchronous, including glob-stream, when using
synchronous filesystem backends. Reintroduce the callback wrapping
behaviour so that the assumption holds true once again.