### PR TITLE
Make BrowserFS usable in a Web Worker again

### DIFF
--- a/src/webpack.config.js
+++ b/src/webpack.config.js
@@ -30,7 +30,10 @@ module.exports = {
     path: __dirname,
     filename: '..' + path.sep + 'build' + path.sep + 'browserfs.' + (release ? 'min.js' : 'js'),
     libraryTarget: 'umd',
-    library: 'BrowserFS'
+    library: 'BrowserFS',
+    // Work around https://github.com/webpack/webpack/issues/6642 until
+    // https://github.com/webpack/webpack/issues/6525 lands.
+    globalObject: 'this',
   },
   resolve: {
     extensions: ['.js', '.json'],


### PR DESCRIPTION
Webpack 4 introduced a regression that causes 'umd' libraries to be
unusable in Web Workers.
https://github.com/webpack/webpack/issues/6642 https://github.com/webpack/webpack/issues/6677

This regression will be fixed with the introduction of a new 'universal'
target (https://github.com/webpack/webpack/issues/6525) but that feature
is scheduled for Webpack 5.

Apply the recommended workaround to get back the old Webpack 3
behaviour.