### PR TITLE
Get rid of TypeError

### DIFF
--- a/src/backend/IndexedDB.ts
+++ b/src/backend/IndexedDB.ts
@@ -218,7 +218,7 @@ export default class IndexedDBFileSystem extends AsyncKeyValueFileSystem {
   /**
    * Constructs an IndexedDB file system with the given options.
    */
-  public static Create(opts: IndexedDBFileSystemOptions, cb: BFSCallback<IndexedDBFileSystem>): void {
+  public static Create(opts: IndexedDBFileSystemOptions = {}, cb: BFSCallback<IndexedDBFileSystem>): void {
     IndexedDBStore.Create(opts.storeName ? opts.storeName : 'browserfs', (e, store?) => {
       if (store) {
         const idbfs = new IndexedDBFileSystem(typeof(opts.cacheSize) === 'number' ? opts.cacheSize : 100);


### PR DESCRIPTION
The example omits the options object, and other backend types allow it as well.  Currently the error `Cannot read property 'storeName' of undefined` is thrown if the options object is missing.  Providing a default value prevents this.