### PR TITLE
Localize Dropbox readdir path.

### DIFF
--- a/src/backend/Dropbox.ts
+++ b/src/backend/Dropbox.ts
@@ -535,7 +535,8 @@ function ProcessListFolderError(e: DropboxTypes.Error<DropboxTypes.files.ListFol
 }
 
 function ContinueReadingDir(client: DropboxClient, path: string, res: DropboxTypes.files.ListFolderResult, previousEntries: string[], cb: BFSCallback<string[]>): void {
-  const newEntries = <string[]> res.entries.map((e) => e.path_display).filter((p) => !!p);
+  // Filter entries with no path_display, then localize the path (Dropbox always return absolute paths when listing dirs).
+  const newEntries = <string[]> res.entries.filter((e) => !!e.path_display).map((e) => (<string> e.path_display).substr(path.length));
   const entries = previousEntries.concat(newEntries);
   if (!res.has_more) {
     cb(null, entries);


### PR DESCRIPTION
Dropbox always returns the absolute path for the file, but readdir should instead return the localized path (the bare filename).

Fixes #276 