### PR TITLE
Support fs.open/fs.openSync for directories

### DIFF
--- a/src/backend/Emscripten.ts
+++ b/src/backend/Emscripten.ts
@@ -253,10 +253,6 @@ export default class EmscriptenFileSystem extends SynchronousFileSystem {
   public openSync(p: string, flag: FileFlag, mode: number): EmscriptenFile {
     try {
       const stream = this._FS.open(p, flag.getFlagString(), mode);
-      if (this._FS.isDir(stream.node.mode)) {
-        this._FS.close(stream);
-        throw ApiError.EISDIR(p);
-      }
       return new EmscriptenFile(this, this._FS, p, stream);
     } catch (e) {
       throw convertError(e, p);

--- a/src/backend/HTTPRequest.ts
+++ b/src/backend/HTTPRequest.ts
@@ -271,13 +271,17 @@ export default class HTTPRequest extends BaseFileSystem implements FileSystem {
     if (inode === null) {
       return cb(ApiError.ENOENT(path));
     }
-    if (isFileInode<Stats>(inode)) {
-      const stats = inode.getData();
+    if (isFileInode<Stats>(inode) || isDirInode<Stats>(inode)) {
       switch (flags.pathExistsAction()) {
         case ActionType.THROW_EXCEPTION:
         case ActionType.TRUNCATE_FILE:
           return cb(ApiError.EEXIST(path));
         case ActionType.NOP:
+          if (isDirInode<Stats>(inode)) {
+            const stats = inode.getStats();
+            return cb(null, new NoSyncFile(self, path, flags, stats, stats.fileData || undefined));
+          }
+          const stats = inode.getData();
           // Use existing file contents.
           // XXX: Uh, this maintains the previously-used flag.
           if (stats.fileData) {
@@ -298,7 +302,7 @@ export default class HTTPRequest extends BaseFileSystem implements FileSystem {
           return cb(new ApiError(ErrorCode.EINVAL, 'Invalid FileMode object.'));
       }
     } else {
-      return cb(ApiError.EISDIR(path));
+      return cb(ApiError.EPERM(path));
     }
   }
 
@@ -312,13 +316,17 @@ export default class HTTPRequest extends BaseFileSystem implements FileSystem {
     if (inode === null) {
       throw ApiError.ENOENT(path);
     }
-    if (isFileInode<Stats>(inode)) {
-      const stats = inode.getData();
+    if (isFileInode<Stats>(inode) || isDirInode<Stats>(inode)) {
       switch (flags.pathExistsAction()) {
         case ActionType.THROW_EXCEPTION:
         case ActionType.TRUNCATE_FILE:
           throw ApiError.EEXIST(path);
         case ActionType.NOP:
+          if (isDirInode<Stats>(inode)) {
+            const stats = inode.getStats();
+            return new NoSyncFile(this, path, flags, stats, stats.fileData || undefined);
+          }
+          const stats = inode.getData();
           // Use existing file contents.
           // XXX: Uh, this maintains the previously-used flag.
           if (stats.fileData) {
@@ -334,7 +342,7 @@ export default class HTTPRequest extends BaseFileSystem implements FileSystem {
           throw new ApiError(ErrorCode.EINVAL, 'Invalid FileMode object.');
       }
     } else {
-      throw ApiError.EISDIR(path);
+      throw ApiError.EPERM(path);
     }
   }
 

--- a/src/backend/IsoFS.ts
+++ b/src/backend/IsoFS.ts
@@ -1274,8 +1274,8 @@ export default class IsoFS extends SynchronousFileSystem implements FileSystem {
       throw ApiError.ENOENT(p);
     } else if (record.isSymlink(this._data)) {
       return this.openSync(path.resolve(p, record.getSymlinkPath(this._data)), flags, mode);
-    } else if (!record.isDirectory(this._data)) {
-      const data = record.getFile(this._data);
+    } else {
+      const data = !record.isDirectory(this._data) ? record.getFile(this._data) : undefined;
       const stats = this._getStats(p, record)!;
       switch (flags.pathExistsAction()) {
         case ActionType.THROW_EXCEPTION:
@@ -1286,8 +1286,6 @@ export default class IsoFS extends SynchronousFileSystem implements FileSystem {
         default:
           throw new ApiError(ErrorCode.EINVAL, 'Invalid FileMode object.');
       }
-    } else {
-      throw ApiError.EISDIR(p);
     }
   }
 

--- a/src/core/file_system.ts
+++ b/src/core/file_system.ts
@@ -427,9 +427,6 @@ export class BaseFileSystem {
         }
       } else {
         // File exists.
-        if (stats && stats.isDirectory()) {
-          return cb(ApiError.EISDIR(p));
-        }
         switch (flag.pathExistsAction()) {
           case ActionType.THROW_EXCEPTION:
             return cb(ApiError.EEXIST(p));
@@ -511,9 +508,6 @@ export class BaseFileSystem {
     }
 
     // File exists.
-    if (stats.isDirectory()) {
-      throw ApiError.EISDIR(p);
-    }
     switch (flag.pathExistsAction()) {
       case ActionType.THROW_EXCEPTION:
         throw ApiError.EEXIST(p);


### PR DESCRIPTION
* it should allow open file even if it's directory.
* underlying API can use file descriptor for example for listing directory files (readdir)
* closes #244

You can reproduce the behavior using this snippet in node.js
```js
const fs = require('fs');
var fd = fs.openSync('./this-is-directory', 'r');
fs.closeSync(fd);
```