### PR TITLE
File System Access Backend

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@types/mocha": "~5.2.5",
     "@types/node": "~10.5.8",
     "@types/rimraf": "~2.0.2",
+    "@types/wicg-file-system-access": "^2020.9.4",
     "archiver": "~2.1.1",
     "async-es": "~2.6.1",
     "bfs-path": "~0.1.2",
@@ -68,7 +69,7 @@
     "source-map-loader": "~0.2.3",
     "tslint": "~5.11.0",
     "typedoc": "~0.11.1",
-    "typescript": "~3.0.1",
+    "typescript": "~3.5.3",
     "webpack": "~4.16.5",
     "webpack-cli": "~3.1.0",
     "webpack-dev-server": "~3.1.5"

--- a/src/backend/FileSystemAccess.ts
+++ b/src/backend/FileSystemAccess.ts
@@ -1,0 +1,333 @@
+import { basename, dirname, join } from "path";
+import { ApiError, ErrorCode } from "../core/api_error";
+import { File } from "../core/file";
+import { FileFlag } from "../core/file_flag";
+import {
+  BaseFileSystem,
+  BFSCallback,
+  BFSOneArgCallback,
+  FileSystem,
+  FileSystemOptions,
+} from "../core/file_system";
+import { default as Stats, FileType } from "../core/node_fs_stats";
+import { NoSyncFile } from "../generic/preload_file";
+
+interface FileSystemAccessFileSystemOptions {
+  handle: FileSystemDirectoryHandle;
+}
+
+type FileSystemKeysIterator = AsyncIterableIterator<string> & {
+  next: () => Promise<IteratorResult<string>>;
+};
+
+type GlobalFile = globalThis.File & {
+  arrayBuffer: () => Promise<ArrayBuffer>;
+};
+
+const handleError =
+  (cb: BFSCallback<never>, path = "") =>
+  (error: Error) => {
+    if (error.name === "NotFoundError") {
+      return cb(ApiError.ENOENT(path));
+    }
+
+    cb(error as ApiError);
+  };
+
+const keysToArray = (
+  directoryKeys: FileSystemKeysIterator,
+  cb: BFSCallback<string[]>,
+  path: string
+): void => {
+  const keys: string[] = [];
+  const iterateKeys = (): void => {
+    directoryKeys
+      .next()
+      .then(({ done, value }) => {
+        if (done) return cb(null, keys);
+
+        keys.push(value);
+        iterateKeys();
+      })
+      .catch(handleError(cb, path));
+  };
+
+  iterateKeys();
+};
+
+export default class FileSystemAccessFileSystem
+  extends BaseFileSystem
+  implements FileSystem
+{
+  public static readonly Name = "FileSystemAccess";
+
+  public static readonly Options: FileSystemOptions = {};
+
+  private _handles: { [path: string]: FileSystemHandle };
+
+  private getHandle(path: string, cb: BFSCallback<FileSystemHandle>): void {
+    if (path === "/") return cb(null, this._handles["/"]);
+
+    let walkedPath = "/";
+    const [, ...pathParts] = path.split("/");
+    const getHandleParts = ([pathPart, ...remainingPathParts]: string[]) => {
+      const walkingPath = join(walkedPath, pathPart);
+      const continueWalk = (handle: FileSystemHandle) => {
+        walkedPath = walkingPath;
+        this._handles[walkedPath] = handle;
+
+        if (remainingPathParts.length === 0) {
+          return cb(null, this._handles[path]);
+        }
+
+        getHandleParts(remainingPathParts);
+      };
+      const handle = this._handles[walkedPath] as FileSystemDirectoryHandle;
+
+      handle
+        .getDirectoryHandle(pathPart)
+        .then(continueWalk)
+        .catch((error: Error) => {
+          if (error.name === "TypeMismatchError") {
+            handle
+              .getFileHandle(pathPart)
+              .then(continueWalk)
+              .catch(handleError(cb, walkingPath));
+          } else if (error.message === "Name is not allowed.") {
+            cb(new ApiError(ErrorCode.ENOTSUP, error.message, walkingPath));
+          } else {
+            handleError(cb, walkingPath)(error);
+          }
+        });
+    };
+
+    getHandleParts(pathParts);
+  }
+
+  private constructor(handle: FileSystemDirectoryHandle) {
+    super();
+    this._handles = { "/": handle };
+  }
+
+  public static Create(
+    { handle }: FileSystemAccessFileSystemOptions,
+    cb: BFSCallback<FileSystemAccessFileSystem>
+  ): void {
+    cb(null, new FileSystemAccessFileSystem(handle));
+  }
+
+  public static isAvailable(): boolean {
+    return typeof FileSystemHandle === "function";
+  }
+
+  public getName(): string {
+    return FileSystemAccessFileSystem.Name;
+  }
+
+  public isReadOnly(): boolean {
+    return false;
+  }
+
+  public supportsSymlinks(): boolean {
+    return false;
+  }
+
+  public supportsProps(): boolean {
+    return false;
+  }
+
+  public supportsSynch(): boolean {
+    return false;
+  }
+
+  public rename(oldPath: string, newPath: string, cb: BFSOneArgCallback): void {
+    this.getHandle(oldPath, (sourceError, handle) => {
+      if (sourceError) return cb(sourceError);
+      if (handle instanceof FileSystemDirectoryHandle) {
+        this.readdir(oldPath, (readDirError, files = []) => {
+          if (readDirError) return cb(readDirError);
+          this.mkdir(newPath, "wx", (mkdirError) => {
+            if (mkdirError) return cb(mkdirError);
+            if (files.length === 0) {
+              this.unlink(oldPath, cb);
+            } else {
+              files.forEach((file) =>
+                this.rename(join(oldPath, file), join(newPath, file), () =>
+                  this.unlink(oldPath, cb)
+                )
+              );
+            }
+          });
+        });
+      }
+      if (handle instanceof FileSystemFileHandle) {
+        handle
+          .getFile()
+          .then((oldFile: GlobalFile) =>
+            this.getHandle(dirname(newPath), (destError, destFolder) => {
+              if (destError) return cb(destError);
+              if (destFolder instanceof FileSystemDirectoryHandle) {
+                destFolder
+                  .getFileHandle(basename(newPath), { create: true })
+                  .then((newFile) =>
+                    newFile
+                      .createWritable()
+                      .then((writable) =>
+                        oldFile
+                          .arrayBuffer()
+                          .then((buffer) =>
+                            writable
+                              .write(buffer)
+                              .then(() => {
+                                writable.close();
+                                this.unlink(oldPath, cb);
+                              })
+                              .catch(handleError(cb, newPath))
+                          )
+                          .catch(handleError(cb, oldPath))
+                      )
+                      .catch(handleError(cb, newPath))
+                  )
+                  .catch(handleError(cb, newPath));
+              }
+            })
+          )
+          .catch(handleError(cb, oldPath));
+      }
+    });
+  }
+
+  public writeFile(
+    fname: string,
+    data: any,
+    encoding: string | null,
+    flag: FileFlag,
+    mode: number,
+    cb: BFSOneArgCallback
+  ): void {
+    this.getHandle(dirname(fname), (error, handle) => {
+      if (error) return cb(error);
+      if (handle instanceof FileSystemDirectoryHandle) {
+        handle
+          .getFileHandle(basename(fname), { create: true })
+          .then((file) =>
+            file
+              .createWritable()
+              .then((writable) =>
+                writable
+                  .write(data)
+                  .then(() => {
+                    writable.close();
+                    cb(null);
+                  })
+                  .catch(handleError(cb, fname))
+              )
+              .catch(handleError(cb, fname))
+          )
+          .catch(handleError(cb, fname));
+      }
+    });
+  }
+
+  public stat(path: string, isLstat: boolean, cb: BFSCallback<Stats>): void {
+    this.getHandle(path, (error, handle) => {
+      if (error || !handle) return cb(error);
+      if (handle instanceof FileSystemDirectoryHandle) {
+        return cb(null, new Stats(FileType.DIRECTORY, 4096));
+      }
+      if (handle instanceof FileSystemFileHandle) {
+        handle
+          .getFile()
+          .then(({ lastModified, size }) =>
+            cb(
+              null,
+              new Stats(FileType.FILE, size, undefined, undefined, lastModified)
+            )
+          )
+          .catch(handleError(cb, path));
+      }
+    });
+  }
+
+  public exists(p: string, cb: (exists: boolean) => void): void {
+    this.getHandle(p, (error) => cb(error === null));
+  }
+
+  public openFile(path: string, flags: FileFlag, cb: BFSCallback<File>): void {
+    this.getHandle(path, (error, handle) => {
+      if (error) return cb(error);
+      if (handle instanceof FileSystemFileHandle) {
+        handle
+          .getFile()
+          .then((file: GlobalFile) =>
+            file
+              .arrayBuffer()
+              .then((buffer) =>
+                cb(
+                  null,
+                  new NoSyncFile(
+                    this,
+                    path,
+                    flags,
+                    new Stats(
+                      FileType.FILE,
+                      file.size,
+                      undefined,
+                      undefined,
+                      file.lastModified
+                    ),
+                    Buffer.from(buffer)
+                  )
+                )
+              )
+              .catch(handleError(cb, path))
+          )
+          .catch(handleError(cb, path));
+      }
+    });
+  }
+
+  public unlink(path: string, cb: BFSOneArgCallback): void {
+    this.getHandle(dirname(path), (error, handle) => {
+      if (error) return cb(error);
+      if (handle instanceof FileSystemDirectoryHandle) {
+        handle
+          .removeEntry(basename(path), { recursive: true })
+          .then(() => cb(null))
+          .catch(handleError(cb, path));
+      }
+    });
+  }
+
+  public rmdir(path: string, cb: BFSOneArgCallback): void {
+    this.unlink(path, cb);
+  }
+
+  public mkdir(p: string, mode: any, cb: BFSOneArgCallback): void {
+    const overwrite =
+      mode && mode.flag && mode.flag.includes("w") && !mode.flag.includes("x");
+
+    this.getHandle(p, (_existingError, existingHandle) => {
+      if (existingHandle && !overwrite) return cb(ApiError.EEXIST(p));
+
+      this.getHandle(dirname(p), (error, handle) => {
+        if (error) return cb(error);
+        if (handle instanceof FileSystemDirectoryHandle) {
+          handle
+            .getDirectoryHandle(basename(p), { create: true })
+            .then(() => cb(null))
+            .catch(handleError(cb, p));
+        }
+      });
+    });
+  }
+
+  public readdir(path: string, cb: BFSCallback<string[]>): void {
+    this.getHandle(path, (readError, handle) => {
+      if (readError) return cb(readError);
+      if (handle instanceof FileSystemDirectoryHandle) {
+        keysToArray(handle.keys() as FileSystemKeysIterator, cb, path);
+      }
+    });
+  }
+}

--- a/src/backend/FileSystemAccess.ts
+++ b/src/backend/FileSystemAccess.ts
@@ -94,7 +94,7 @@ export default class FileSystemAccessFileSystem
               .then(continueWalk)
               .catch(handleError(cb, walkingPath));
           } else if (error.message === "Name is not allowed.") {
-            cb(new ApiError(ErrorCode.ENOTSUP, error.message, walkingPath));
+            cb(new ApiError(ErrorCode.EACCES, error.message, walkingPath));
           } else {
             handleError(cb, walkingPath)(error);
           }

--- a/src/core/backends.ts
+++ b/src/core/backends.ts
@@ -4,6 +4,7 @@ import {checkOptions} from './util';
 import AsyncMirror from '../backend/AsyncMirror';
 import Dropbox from '../backend/Dropbox';
 import Emscripten from '../backend/Emscripten';
+import FileSystemAccess from '../backend/FileSystemAccess';
 import FolderAdapter from '../backend/FolderAdapter';
 import HTML5FS from '../backend/HTML5FS';
 import InMemory from '../backend/InMemory';
@@ -17,7 +18,7 @@ import ZipFS from '../backend/ZipFS';
 import IsoFS from '../backend/IsoFS';
 
 // Monkey-patch `Create` functions to check options before file system initialization.
-[AsyncMirror, Dropbox, Emscripten, FolderAdapter, HTML5FS, InMemory, IndexedDB, IsoFS, LocalStorage, MountableFileSystem, OverlayFS, WorkerFS, HTTPRequest, ZipFS].forEach((fsType: FileSystemConstructor) => {
+[AsyncMirror, Dropbox, Emscripten, FileSystemAccess, FolderAdapter, HTML5FS, InMemory, IndexedDB, IsoFS, LocalStorage, MountableFileSystem, OverlayFS, WorkerFS, HTTPRequest, ZipFS].forEach((fsType: FileSystemConstructor) => {
   const create = fsType.Create;
   fsType.Create = function(opts?: any, cb?: BFSCallback<FileSystem>): void {
     const oneArg = typeof(opts) === "function";
@@ -39,7 +40,7 @@ import IsoFS from '../backend/IsoFS';
 /**
  * @hidden
  */
-const Backends = { AsyncMirror, Dropbox, Emscripten, FolderAdapter, HTML5FS, InMemory, IndexedDB, IsoFS, LocalStorage, MountableFileSystem, OverlayFS, WorkerFS, HTTPRequest, XmlHttpRequest: HTTPRequest, ZipFS };
+const Backends = { AsyncMirror, Dropbox, Emscripten, FileSystemAccess, FolderAdapter, HTML5FS, InMemory, IndexedDB, IsoFS, LocalStorage, MountableFileSystem, OverlayFS, WorkerFS, HTTPRequest, XmlHttpRequest: HTTPRequest, ZipFS };
 // Make sure all backends cast to FileSystemConstructor (for type checking)
 const _: {[name: string]: FileSystemConstructor} = Backends;
 // tslint:disable-next-line:no-unused-expression

--- a/yarn.lock
+++ b/yarn.lock
@@ -134,6 +134,11 @@
     "@types/glob" "*"
     "@types/node" "*"
 
+"@types/wicg-file-system-access@^2020.9.4":
+  version "2020.9.4"
+  resolved "https://registry.yarnpkg.com/@types/wicg-file-system-access/-/wicg-file-system-access-2020.9.4.tgz#83f255d6bd20b0ae131d555693473d15a0574e92"
+  integrity sha512-o43jUljwP0ZrQ927mPjGdJaBMfS12nf3VPj6Z52fMucxILrSs8tnfLbMDSn6cP3hrrLChc3SYneeEvecknNVtA==
+
 "@webassemblyjs/ast@1.5.13":
   version "1.5.13"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.5.13.tgz#81155a570bd5803a30ec31436bc2c9c0ede38f25"
@@ -4905,9 +4910,10 @@ typescript@2.7.2:
   version "2.7.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.2.tgz#2d615a1ef4aee4f574425cdff7026edf81919836"
 
-typescript@~3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.0.1.tgz#43738f29585d3a87575520a4b93ab6026ef11fdb"
+typescript@~3.5.3:
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.3.tgz#c830f657f93f1ea846819e929092f5fe5983e977"
+  integrity sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==
 
 uglify-es@^3.3.4:
   version "3.3.9"


### PR DESCRIPTION
This is my attempt to use the [File System Access API](https://developer.mozilla.org/en-US/docs/Web/API/File_System_Access_API) as a backend for BrowserFS. I'm open to any comments/suggestions. I avoided `async`/`await` as the build command started complaining about generators. Currently this supports `rename`, `writeFile`, `stat`, `exists`, `readFile`, `unlink`, `rmdir`, `mkdir` & `readdir`. To get the types working I needed to add `@types/wicg-file-system-access` and upgrade `typescript`.

Usage:
```ts
type IFileSystemAccess = {
  FileSystem: {
    FileSystemAccess: {
      Create: (
        opts: { handle: FileSystemDirectoryHandle },
        cb: BFSCallback<FileSystem>
      ) => void;
    };
  };
};
```

To get the `handle` you need to call:

```ts
const handle = await window.showDirectoryPicker();
```